### PR TITLE
Splits out `stepVty`, runs single step of event loop

### DIFF
--- a/src/Brick/Render.hs
+++ b/src/Brick/Render.hs
@@ -1,6 +1,7 @@
 module Brick.Render
   ( Render
   , RenderM
+  , RenderState
 
   , Result
   , image

--- a/src/Brick/Render/Internal.hs
+++ b/src/Brick/Render/Internal.hs
@@ -145,6 +145,9 @@ instance IsString Render where
 instance Default Result where
     def = Result V.emptyImage [] []
 
+instance Default RenderState where
+    def = RS M.empty []
+
 getContext :: RenderM Context
 getContext = ask
 


### PR DESCRIPTION
Because I need to stop and start Vty, I unfortunately have to reach pretty deep into your event loop code. This change adds a new public function that runs one step of the event loop. It requires making `RenderState` public (with a `Default` instance, but without constructors). Adding `stepVty` is the best idea that I have come up with to avoid making the internal details of `RenderState` public.

You have probably already found it, but here is a highlight of the spot where I use `stepVty`:
https://github.com/hallettj/locutoria/blob/32e38f48d0368d0811a018d1340c07337332c887/Network/Mail/Locutoria/Cli/Ui.hs#L49-L54