### PR TITLE
Fix selection handling in listReplace

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -90,6 +90,21 @@ library
                        template-haskell,
                        deepseq >= 1.3 && < 1.5
 
+test-suite brick-tests
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            TestDriver.hs
+  other-modules:      ListTest
+  default-language:   Haskell2010
+  build-depends:      base,
+                      brick,
+                      tasty,
+                      tasty-hunit,
+                      lens,
+                      vector,
+                      QuickCheck,
+                      tasty-quickcheck
+
 executable brick-visibility-demo
   if !flag(demos)
     Buildable: False

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -237,8 +237,11 @@ listSelectedElement l = do
 -- the corresponding index in `ys`.
 maintainSel :: (Eq e) => [e] -> [e] -> Int -> Int
 maintainSel xs ys sel = let hunks = D.getDiff xs ys
-                        in merge 0 sel hunks
+                        in clamp 0 (length ys - 1) $ merge 0 sel hunks
 
+-- Given (0, sel, diff), computes the value 'sel' would have after 'diff'
+-- was applied. Retuns -1 if the selected item doesn't appear anywhere in
+-- the replacement list.
 merge :: (Eq e) => Int -> Int -> [D.Diff e] -> Int
 merge _   sel []                 = sel
 merge idx sel (h:hs) | idx > sel = sel

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -243,16 +243,13 @@ merge :: (Eq e) => Int -> Int -> [D.Diff e] -> Int
 merge _   sel []                 = sel
 merge idx sel (h:hs) | idx > sel = sel
                      | otherwise = case h of
-    D.Both _ _ -> merge sel (idx + 1) hs
+    D.Both _ _ -> merge (idx + 1) sel hs
 
     -- element removed in new list
-    D.First _  -> let newSel = if idx < sel
-                               then sel - 1
-                               else sel
-                  in merge newSel idx hs
+    D.First _  -> merge idx (sel - 1) hs
 
     -- element added in new list
     D.Second _ -> let newSel = if idx <= sel
                                then sel + 1
                                else sel
-                  in merge newSel (idx + 1) hs
+                  in merge (idx + 1) newSel hs

--- a/test/ListTest.hs
+++ b/test/ListTest.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module ListTest ( tests ) where
+
+import Brick.Widgets.List
+
+import Control.Applicative
+import Control.Lens
+import qualified Data.Vector as V
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+
+
+tests :: TestTree
+tests = testGroup "List" [ listReplaceTests ]
+
+listReplaceTests :: TestTree
+listReplaceTests = testGroup "listReplace" [listReplaceUnitTests, listReplaceProperties]
+
+listReplaceUnitTests :: TestTree
+listReplaceUnitTests = testGroup "Unit tests"
+    [ testCase "with same list" $
+          listReplace (V.fromList [1,2,3]) selectedList `assertList` ([1,2,3], Just 1)
+
+    , testCase "with empty list" $
+          listReplace V.empty selectedList `assertList` ([], Nothing)
+
+    , testCase "empty list with nonempty list" $
+          listReplace (V.fromList [1,2,3]) emptyList `assertList` ([1,2,3], Just 0)
+
+    , testCase "insert one element in front of selection" $
+          listReplace (V.fromList [1,0,2,3]) selectedList `assertList` ([1,0,2,3], Just 2)
+
+    , testCase "insert one element after selection" $
+          listReplace (V.fromList [1,2,0,3]) selectedList `assertList` ([1,2,0,3], Just 1)
+
+    , testCase "delete one element in front of selection" $
+          listReplace (V.fromList [2,3]) selectedList `assertList` ([2,3], Just 0)
+
+    , testCase "delete one element after selection" $
+          listReplace (V.fromList [1,2]) selectedList `assertList` ([1,2], Just 1)
+
+    , testCase "deletion with multiple equal elements" $
+          listReplace (V.fromList [2,2,3]) multiList `assertList` ([2,2,3], Just 1)
+
+    , testCase "insertion with multiple equal elements" $
+          listReplace (V.fromList [0,2,1,2,3]) selectedList `assertList` ([0,2,1,2,3], Just 3)
+    ]
+
+    where
+        sampleList = list "list" (V.fromList [1, 2, 3]) 1 :: List Int
+        selectedList = sampleList & listSelectedL .~ Just 1
+        emptyList = list "empty" V.empty 1 :: List Int
+        multiList = listInsert 0 2 selectedList -- [2,1,2,3]
+
+listReplaceProperties :: TestTree
+listReplaceProperties = testGroup "Properties"
+    [ testProperty "selection always stays within bounds" $
+          forAll listGen $ \lst ->
+          forAll vecGen  $ \elems ->
+              propReplaceBounds elems lst
+
+    , testProperty "selected element stays the same" $
+          forAll listGen $ \lst ->
+          forAll vecGen  $ \elems ->
+              propReplaceSelectionEq elems lst
+    ]
+
+propReplaceBounds :: (Eq e) => V.Vector e -> List e -> Property
+propReplaceBounds elems lst = case listReplace elems lst ^. listSelectedL of
+    Nothing -> property True
+    Just idx -> counterexample ("selection: " ++ show idx) $ idx >= 0 .&&. idx < V.length elems
+
+propReplaceSelectionEq :: (Show e, Eq e) => V.Vector e -> List e -> Property
+propReplaceSelectionEq elems lst = case listSelectedElement lst of
+    Nothing -> property Discard
+    Just (_, e) -> e `V.elem` elems ==>
+                   nothingOrEqual (listSelectedElement (listReplace elems lst))
+
+        where
+            nothingOrEqual Nothing = property True
+            nothingOrEqual (Just (i, e')) = i >= 0 && i < V.length elems ==> e === e'
+
+listGen :: Gen (List Int)
+listGen = do
+    elems <- vecGen
+    selection <- if V.null elems
+                    then return Nothing
+                    else Just <$> choose (0, V.length elems - 1)
+    return (list "list" elems 1 & listSelectedL .~ selection)
+
+-- Required by QuickCheck
+instance Show e => Show (List e) where
+    show lst = show (lst^.listElementsL.to V.toList) ++ " !! " ++ show (lst^.listSelectedL)
+
+vecGen :: Gen (V.Vector Int)
+vecGen = V.fromList <$> arbitrary
+
+assertList :: (Eq e, Show e) => List e -> ([e], Maybe Int) -> Assertion
+assertList lst (elems, selection) = do
+    assertEqual "contents" elems (lst^.listElementsL.to V.toList)
+    assertEqual "selected element" selection (lst^.listSelectedL)

--- a/test/TestDriver.hs
+++ b/test/TestDriver.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import qualified ListTest as List
+
+import Test.Tasty
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests" [List.tests]


### PR DESCRIPTION
The previous implementation of the merge function was buggy and could
for example return out of bounds indices even for non-empty lists
and generally didn't behave as intended.

This new implementation should be better. It now returns -1 if the
replacement list is empty, but this case is excluded on the caller side
in listReplace.

Please review thoroughly, since the code is a little hairy and I'm not sure
 I thought of all the edge cases.

Anyway, it's hard to come up with a correctness specification for this
selection preservation in listReplace, because it depends crucially on
the ability of the diff algorithm to capture the changes correctly. Maybe
 it would be easier to just assume that elements are distinct and select
 the first item, that compares equal to the previously selected one.