### PR TITLE
Apply hlint hints

### DIFF
--- a/programs/LayerDemo.hs
+++ b/programs/LayerDemo.hs
@@ -8,12 +8,9 @@ import Data.Default
 import qualified Graphics.Vty as V
 
 import qualified Brick.Types as T
-import Brick.Types (rowL, columnL)
+import Brick.Types (rowL, columnL, Widget)
 import qualified Brick.Main as M
 import qualified Brick.Widgets.Border as B
-import Brick.Types
-  ( Widget
-  )
 import Brick.Widgets.Core
   ( translateBy
   , str

--- a/programs/SuspendAndResumeDemo.hs
+++ b/programs/SuspendAndResumeDemo.hs
@@ -61,5 +61,5 @@ theApp =
         }
 
 main :: IO ()
-main = do
+main =
     void $ defaultMain theApp initialState

--- a/programs/ViewportScrollDemo.hs
+++ b/programs/ViewportScrollDemo.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 

--- a/src/Brick/Main.hs
+++ b/src/Brick/Main.hs
@@ -135,7 +135,7 @@ data InternalNext a = InternalSuspendAndResume RenderState (IO a)
                     | InternalHalt a
 
 runWithNewVty :: IO Vty -> Chan e -> App s e -> RenderState -> s -> IO (InternalNext s)
-runWithNewVty buildVty chan app initialRS initialSt = do
+runWithNewVty buildVty chan app initialRS initialSt =
     withVty buildVty $ \vty -> do
         pid <- forkIO $ supplyVtyEvents vty (appLiftVtyEvent app) chan
         let runInner rs st = do

--- a/src/Brick/Widgets/Center.hs
+++ b/src/Brick/Widgets/Center.hs
@@ -15,6 +15,7 @@ module Brick.Widgets.Center
 where
 
 import Control.Lens ((^.), (&), (.~), to)
+import Data.Maybe (fromMaybe)
 import Graphics.Vty (imageWidth, imageHeight, horizCat, charFill, vertCat)
 
 import Brick.Types
@@ -30,7 +31,7 @@ hCenter = hCenterWith Nothing
 -- to either side of the centered widget (defaults to space).
 hCenterWith :: Maybe Char -> Widget -> Widget
 hCenterWith mChar p =
-    let ch = maybe ' ' id mChar
+    let ch = fromMaybe ' ' mChar
     in Widget Greedy (vSize p) $ do
            result <- render p
            c <- getContext
@@ -60,7 +61,7 @@ vCenter = vCenterWith Nothing
 -- widget (defaults to space).
 vCenterWith :: Maybe Char -> Widget -> Widget
 vCenterWith mChar p =
-    let ch = maybe ' ' id mChar
+    let ch = fromMaybe ' ' mChar
     in Widget (hSize p) Greedy $ do
            result <- render p
            c <- getContext

--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -65,8 +65,8 @@ module Brick.Widgets.Core
 where
 
 import Control.Applicative
-import Control.Lens ((^.), (.~), (&), (%~), to, _1, _2, each, to, ix)
-import Control.Monad (when)
+import Control.Lens ((^.), (.~), (&), (%~), to, _1, _2, each, to, ix, Lens')
+import Control.Monad ((>=>),when)
 import Control.Monad.Trans.State.Lazy
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Class (lift)
@@ -76,7 +76,6 @@ import Data.Monoid ((<>), mempty)
 import qualified Data.Map as M
 import qualified Data.Function as DF
 import Data.List (sortBy, partition)
-import Control.Lens (Lens')
 import qualified Graphics.Vty as V
 import Control.DeepSeq
 
@@ -337,7 +336,7 @@ hBoxRenderer =
 -- returned along with the translated cursor positions and visibility
 -- requests.
 renderBox :: BoxRenderer -> [Widget] -> Widget
-renderBox br ws = do
+renderBox br ws =
     Widget (maximum $ hSize <$> ws) (maximum $ vSize <$> ws) $ do
       c <- getContext
 
@@ -389,7 +388,7 @@ renderBox br ws = do
 -- and defers to the limited widget vertically.
 hLimit :: Int -> Widget -> Widget
 hLimit w p =
-    Widget Fixed (vSize p) $ do
+    Widget Fixed (vSize p) $
       withReaderT (& availWidthL .~ w) $ render $ cropToContext p
 
 -- | Limit the space available to the specified widget to the specified
@@ -398,7 +397,7 @@ hLimit w p =
 -- defers to the limited widget horizontally.
 vLimit :: Int -> Widget -> Widget
 vLimit h p =
-    Widget (hSize p) Fixed $ do
+    Widget (hSize p) Fixed $
       withReaderT (& availHeightL .~ h) $ render $ cropToContext p
 
 -- | When drawing the specified widget, set the current attribute used
@@ -410,7 +409,7 @@ vLimit h p =
 -- 'withDefAttr'.
 withAttr :: AttrName -> Widget -> Widget
 withAttr an p =
-    Widget (hSize p) (vSize p) $ do
+    Widget (hSize p) (vSize p) $
       withReaderT (& ctxAttrNameL .~ an) (render p)
 
 -- | Update the attribute map while rendering the specified widget: set
@@ -426,7 +425,7 @@ withDefAttr an p =
 -- the specified transformation.
 updateAttrMap :: (AttrMap -> AttrMap) -> Widget -> Widget
 updateAttrMap f p =
-    Widget (hSize p) (vSize p) $ do
+    Widget (hSize p) (vSize p) $
         withReaderT (& ctxAttrMapL %~ f) (render p)
 
 -- | When rendering the specified widget, force all attribute lookups
@@ -554,7 +553,7 @@ viewport vpname typ p =
           release = case typ of
             Vertical -> vRelease
             Horizontal -> hRelease
-            Both -> \w -> vRelease w >>= hRelease
+            Both ->vRelease >=> hRelease
           released = case release p of
             Just w -> w
             Nothing -> case typ of

--- a/src/Brick/Widgets/Internal.hs
+++ b/src/Brick/Widgets/Internal.hs
@@ -37,7 +37,7 @@ renderFinal aMap layerRenders sz chooseCursor rs = (newRS, pic, theCursor)
 -- dimensions in the rendering context.
 cropToContext :: Widget -> Widget
 cropToContext p =
-    Widget (hSize p) (vSize p) $ (render p >>= cropResultToContext)
+    Widget (hSize p) (vSize p) (render p >>= cropResultToContext)
 
 cropResultToContext :: Result -> RenderM Result
 cropResultToContext result = do

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -36,6 +36,7 @@ where
 
 import Control.Applicative ((<$>))
 import Control.Lens ((^.), (&), (.~), _2)
+import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Graphics.Vty (Event(..), Key(..))
 import qualified Data.Vector as V
@@ -123,9 +124,7 @@ drawListElements l drawElem =
         c <- getContext
 
         let es = V.slice start num (l^.listElementsL)
-            idx = case l^.listSelectedL of
-                Nothing -> 0
-                Just i -> i
+            idx = fromMaybe 0 (l^.listSelectedL)
 
             start = max 0 $ idx - numPerHeight + 1
             num = min (numPerHeight * 2) (V.length (l^.listElementsL) - start)

--- a/src/Brick/Widgets/ProgressBar.hs
+++ b/src/Brick/Widgets/ProgressBar.hs
@@ -9,6 +9,7 @@ module Brick.Widgets.ProgressBar
 where
 
 import Control.Lens ((^.))
+import Data.Maybe (fromMaybe)
 import Data.Monoid
 
 import Brick.Types
@@ -36,7 +37,7 @@ progressBar mLabel progress =
     Widget Greedy Fixed $ do
         c <- getContext
         let barWidth = c^.availWidthL
-            label = maybe "" id mLabel
+            label = fromMaybe "" mLabel
             labelWidth = length label
             spacesWidth = barWidth - labelWidth
             leftPart = replicate (spacesWidth `div` 2) ' '


### PR DESCRIPTION
I ran `hlint` and applied some of the suggestions, I restricted myself to the ones that are hopefully undisputed ;)  If there's anything that you don't like I'll undo it.

- redundant brackets
- `fromMaybe x mx` instead of `maybe x id mx`
- redundant do
- functor law: `f <$> g <$> m` == `f . g <$> m`
- combine import statements, e.g.
```
import Brick.Types (rowL, columnL)
import Bricket.Types (Widget)
```

changed to

```
import Brick.Types (rowL, columnL, Widget)
```

This reduces the number of hints from `103` to `25`, of which many are of the following type:

```
./src/Brick/Widgets/Border.hs:113:20: Warning: Move brackets to avoid $
Found:
  (Widget Fixed Fixed $ return middleResult) <+> vBorder
Why not:
  Widget Fixed Fixed (return middleResult) <+> vBorder
```

Given that this change is a little more subjective, I chose to ignore these for now.  If you don't mind either way, I would also be happy to apply the remaining hints.

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
