### PR TITLE
Derive `List` instances: Functor, Foldable, Traversable

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable#-}
+{-# LANGUAGE DeriveTraversable #-}
 -- | This module provides a scrollable list type and functions for
 -- manipulating and rendering it.
 module Brick.Widgets.List
@@ -36,6 +39,8 @@ where
 
 import Control.Applicative ((<$>))
 import Control.Lens ((^.), (&), (.~), _2)
+import Data.Foldable (Foldable)
+import Data.Traversable (Traversable)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Graphics.Vty (Event(..), Key(..))
@@ -60,7 +65,7 @@ data List e =
          , listSelected :: !(Maybe Int)
          , listName :: Name
          , listItemHeight :: Int
-         }
+         } deriving (Functor, Foldable, Traversable)
 
 suffixLenses ''List
 


### PR DESCRIPTION
I think adding those instances makes it much easier to work with lists, e.g. operations like `length` for `List a` are automatically available via the `Foldable` instances.

Btw, as you might notice by now, I am currently in the process of migrating one of my personal projects from` vty-ui` to `brick`.  I just wanted to let you know that up until now I really like the new design!  Especially that most operations (on widgets etc) are pure ;)

Best,
Markus