### PR TITLE
Derive Functor instance for 'Next'

### DIFF
--- a/src/Brick/Types/Internal.hs
+++ b/src/Brick/Types/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Brick.Types.Internal
@@ -97,6 +98,7 @@ type EventState = [(Name, ScrollRequest)]
 data Next a = Continue a
             | SuspendAndResume (IO a)
             | Halt a
+            deriving Functor
 
 -- | Scrolling direction.
 data Direction = Up


### PR DESCRIPTION
Missed that one recently and though adding it would be nice.

Btw, you did an awesome job with the `brick` redesign of `vty-ui` I am enjoying the `event-loop` + `pure state` very much :) :+1: 