### PR TITLE
Add support for ⬌ in dialog

### DIFF
--- a/src/Brick/Widgets/Dialog.hs
+++ b/src/Brick/Widgets/Dialog.hs
@@ -45,7 +45,8 @@ import Brick.AttrMap
 
 -- | Dialogs present a window with a title (optional), a body, and
 -- buttons (optional). They provide a 'HandleEvent' instance that knows
--- about Tab and Shift-Tab for changing which button is active. Dialog
+-- about Tab and Shift-Tab as well as ArrowLeft and ArrowRight
+-- for changing which button is active. Dialog
 -- buttons are labeled with strings and map to values of type 'a', which
 -- you choose.
 --
@@ -71,6 +72,8 @@ handleDialogEvent ev d =
     return $ case ev of
         EvKey (KChar '\t') [] -> nextButtonBy 1 d
         EvKey KBackTab [] -> nextButtonBy (-1) d
+        EvKey KRight [] -> nextButtonBy 1 d
+        EvKey KLeft [] -> nextButtonBy (-1) d
         _ -> d
 
 -- | Create a dialog.


### PR DESCRIPTION
In response to #80, after some thoughts, it's probably better to keep the module simple and just add support fort left and right arrow for the dialogs.