### PR TITLE
Add reactive-banana interface [draft]

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -60,6 +60,7 @@ library
     Brick.AttrMap
     Brick.Focus
     Brick.Main
+    Brick.MainBanana
     Brick.Markup
     Brick.Types
     Brick.Util
@@ -90,7 +91,9 @@ library
                        text,
                        text-zipper >= 0.7.1,
                        template-haskell,
-                       deepseq >= 1.3 && < 1.5
+                       deepseq >= 1.3 && < 1.5,
+                       reactive-banana,
+                       stm
 
 executable brick-cache-demo
   if !flag(demos)
@@ -297,3 +300,21 @@ executable brick-border-demo
                        data-default,
                        text,
                        microlens
+
+executable brick-banana-demo
+  -- if !flag(demos)
+  --   Buildable: False
+  hs-source-dirs:      programs
+  ghc-options:         -threaded -Wall -fno-warn-unused-do-bind -O3
+  default-extensions:  CPP
+  default-language:    Haskell2010
+  main-is:             BananaDemo.hs
+  build-depends:       base <= 5,
+                       brick,
+                       vty >= 5.5.0,
+                       data-default,
+                       text,
+                       microlens,
+                       reactive-banana,
+                       containers
+

--- a/programs/BananaDemo.hs
+++ b/programs/BananaDemo.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+
+
+import Brick.MainBanana
+import Brick.Types
+
+import qualified Reactive.Banana as Banana
+import qualified Reactive.Banana.Frameworks as Banana
+
+import Graphics.Vty.Input.Events
+
+import Control.Concurrent.MVar
+
+import Lens.Micro ((<&>))
+
+import Brick.Widgets.Core
+
+import Data.Default
+
+
+
+main :: IO ()
+main = do
+
+  finMVar <- newEmptyMVar
+  startup@(_, startupH) <- Banana.newAddHandler
+
+  network <- Banana.compile $ brickNetwork startup $ \eventE finE -> do
+
+    Banana.reactimate $ finE <&> \() -> putMVar finMVar ()
+
+    curPromptStr <- Banana.accumB "" $ eventE <&> \case
+      Just (EvKey key _mods) -> case key of
+        KEsc    -> const ""
+        KEnter  -> const ""
+        KChar c -> (++[c])
+        KBS     -> init
+        _       -> id
+      _                      -> id
+
+
+    let promptWidget :: Banana.Behavior (Widget String) =
+          curPromptStr <&> \s -> str $ if null s then " " else s
+    let lengthWidget :: Banana.Behavior (Widget String) =
+          curPromptStr <&> str . show . length
+
+    let nextE = eventE <&> \case
+          Just (EvKey KEsc _) -> halt
+          _                   -> continue
+
+    let widgetsB =
+          (\wid1 wid2 -> [wid1 <=> wid2 <=> emptyWidget])
+            <$> promptWidget
+            <*> lengthWidget
+
+    let cursorB = pure $ const Nothing
+    let attrB   = pure $ def
+
+    return $ (nextE, widgetsB, cursorB, attrB)
+
+
+  Banana.actuate network
+  startupH ()
+  takeMVar finMVar
+  Banana.pause network

--- a/src/Brick/MainBanana.hs
+++ b/src/Brick/MainBanana.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Brick.MainBanana
+  ( brickNetwork
+  , continue
+  , halt
+  )
+where
+
+
+
+import qualified Reactive.Banana as Banana
+import qualified Reactive.Banana.Frameworks as Banana
+
+import           Brick.Types                      ( Widget
+                                                  , rowL
+                                                  , columnL
+                                                  , CursorLocation(..)
+                                                  )
+import           Brick.Types.Internal             ( RenderState(..)
+                                                  , Next(..)
+                                                  , EventState(..)
+                                                  )
+import           Brick.Widgets.Internal           ( renderFinal
+                                                  )
+import           Brick.AttrMap
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+
+import           Data.Default
+import           Control.Monad.IO.Class           (liftIO)
+import           Control.Monad
+import           Control.Concurrent
+import           Control.Exception                (finally)
+import           Lens.Micro                       ((^.))
+import           Data.IORef
+
+import           Graphics.Vty
+                                                  ( Vty
+                                                  , Picture(..)
+                                                  , Cursor(..)
+                                                  , Event(..)
+                                                  , update
+                                                  , outputIface
+                                                  , inputIface
+                                                  , displayBounds
+                                                  , shutdown
+                                                  , mkVty
+                                                  )
+import           Graphics.Vty.Input               ( _eventChannel
+                                                  )
+import           Control.Concurrent.STM.TChan
+import           Control.Monad.STM
+
+
+
+brickNetwork
+  :: forall n
+   . Ord n
+  => (Banana.AddHandler (), Banana.Handler ())
+  -> (  Banana.Event (Maybe Event)
+     -> Banana.Event ()
+     -> Banana.MomentIO
+          ( Banana.Event (Next ())
+          , Banana.Behavior [Widget n]
+          , Banana.Behavior
+              ([CursorLocation n] -> Maybe (CursorLocation n))
+          , Banana.Behavior AttrMap
+          )
+     )
+  -> Banana.MomentIO ()
+brickNetwork (startupAH, startupH) interfaceF = do
+  let emptyES   = ES [] []
+      initialRS = RS M.empty (esScrollRequests emptyES) S.empty mempty
+
+  (eventEvent   , eventH   )          <- Banana.newEvent
+  (shutdownEvent, shutdownH)          <- Banana.newEvent
+  startupEvent                        <- Banana.fromAddHandler startupAH
+  (nextE, nextH)                      <- Banana.newEvent
+
+  initState                           <-
+    (=<<) (Banana.switchB (pure Nothing) . fmap (fmap Just))
+      $ Banana.execute
+      $ flip fmap startupEvent
+      $ \() -> liftIO $ do
+          vty           <- liftIO $ do
+            x <- mkVty def
+            return x
+          shutdownIORef <- liftIO $ newIORef False
+          let pumpAction = do
+                loop `finally` shutdown vty
+              loop       = do
+                ev <- atomically (readTChan $ _eventChannel $ inputIface vty)
+                case ev of
+                  (EvResize _ _) ->
+                    eventH
+                      .   Just
+                      .   (\(w, h) -> EvResize w h)
+                      =<< (displayBounds $ outputIface vty)
+                  _ -> eventH $ Just ev
+                sd <- readIORef shutdownIORef
+                unless sd loop
+          liftIO $ do
+            void $ forkIO $ pumpAction
+            void $ forkIO $ eventH $ Nothing
+          let stopper = writeIORef shutdownIORef True
+          return $ pure (vty, stopper)
+
+  (triggerE, widgetB, cursorB, attrB) <- interfaceF eventEvent shutdownEvent
+
+  Banana.reactimate $ nextH <$> triggerE
+
+  rsRef <- liftIO $ newIORef initialRS
+
+  let
+    hand
+      :: Maybe (Vty, IO ())
+      -> [Widget n]
+      -> ([CursorLocation n] -> Maybe (CursorLocation n))
+      -> AttrMap
+      -> Next ()
+      -> IO ()
+    hand mState widgetStack chooseCursor attrs next = do
+      case next of
+        Continue         () -> do
+          case mState of
+            Nothing       -> pure ()
+            Just (vty, _) -> do
+              renderState  <- readIORef rsRef
+              renderState' <- render vty
+                                     widgetStack
+                                     chooseCursor
+                                     attrs
+                                     renderState
+              writeIORef rsRef renderState'
+        SuspendAndResume io -> do
+          mState `forM_` snd
+          io
+          void $ forkIO $ startupH ()
+        Halt             () -> do
+          mState `forM_` snd
+          shutdownH ()
+
+  Banana.reactimate
+    $          hand
+    <$>        initState
+    <*>        widgetB
+    <*>        cursorB
+    <*>        attrB
+    Banana.<@> nextE
+  --   $   flip Banana.apply resultEvent
+  --   $   initState
+  --   <&> \mState (widgetStack, next, chooseCursor, attrMapCur) -> do
+  --         case next of
+  --           Continue         () -> do
+  --             case mState of
+  --               Nothing       -> pure ()
+  --               Just (vty, _) -> do
+  --                 renderState  <- readIORef rsRef
+  --                 renderState' <- render vty
+  --                                        widgetStack
+  --                                        chooseCursor
+  --                                        attrMapCur
+  --                                        renderState
+  --                 writeIORef rsRef renderState'
+  --           SuspendAndResume io -> do
+  --             mState `forM_` snd
+  --             io
+  --             void $ forkIO $ startupH ()
+  --           Halt             () -> do
+  --             mState `forM_` snd
+  --             shutdownH ()
+
+render
+  :: Vty
+  -> [Widget n]
+  -> ([CursorLocation n] -> Maybe (CursorLocation n))
+  -> AttrMap
+  -> RenderState n
+  -> IO (RenderState n)
+render vty widgetStack chooseCursor attrMapCur rs = do
+  sz <- displayBounds $ outputIface vty
+  let (newRS, pic, theCursor) =
+        renderFinal attrMapCur widgetStack sz chooseCursor rs
+      picWithCursor = case theCursor of
+        Nothing  -> pic { picCursor = NoCursor }
+        Just loc -> pic { picCursor = Cursor (loc ^. columnL) (loc ^. rowL) }
+
+  update vty picWithCursor
+
+  return newRS
+
+continue :: Next ()
+continue = Continue ()
+
+halt :: Next ()
+halt = Halt ()


### PR DESCRIPTION
I have made an attempt at #84; directly as a fork because it seemed easy enough to create a rather shallow wrapper around brick functionality.

Work in progress, I have not tested everything (suspend/resume). Seems to work well enough already, but I am thankful for any suggestions. The `brickNetwork` entry point needs some good documentation; apart from that the only things I dislike are reactive-banana specifics: I currently use IORefs for certain state and require a reactimate-roundtrip. For both I am unable to see how to improve. Otoh the effect on performance probably is negligible and the user-interface is not affected.