### PR TITLE
Use DList to avoid repetitive Data.List.++

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -81,6 +81,7 @@ library
                        vty >= 5.12,
                        transformers,
                        data-default,
+                       dlist,
                        containers,
                        microlens >= 0.3.0.0,
                        microlens-th,

--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -93,6 +93,7 @@ import Control.Monad.Trans.Class (lift)
 import qualified Data.Foldable as F
 import qualified Data.Text as T
 import Data.Default
+import qualified Data.DList as DL
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Function as DF
@@ -438,14 +439,14 @@ renderBox br ws =
       let availPrimary = c^.(contextPrimary br)
           availSecondary = c^.(contextSecondary br)
 
-          renderHis _ prev [] = return prev
+          renderHis _ prev [] = return $ DL.toList prev
           renderHis remainingPrimary prev ((i, prim):rest) = do
               result <- render $ limitPrimary br remainingPrimary
                                $ limitSecondary br availSecondary
                                $ cropToContext prim
-              renderHis (remainingPrimary - (result^.imageL.(to $ imagePrimary br))) (prev ++ [(i, result)]) rest
+              renderHis (remainingPrimary - (result^.imageL.(to $ imagePrimary br))) (DL.snoc prev (i, result)) rest
 
-      renderedHis <- renderHis availPrimary [] his
+      renderedHis <- renderHis availPrimary DL.empty his
 
       renderedLows <- case lows of
           [] -> return []


### PR DESCRIPTION
When there are many (>= 10k) items in a `vBox`, the list concatenation in `renderHis` can be really expensive. I have no proper benchmarks but I see a significant latency improvement in [maoe/viewprof](https://github.com/maoe/viewprof) with a large profiling report.