### PR TITLE
Switched to using TBQueue (bounded) instead of Chan (unbounded)

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -58,6 +58,7 @@ library
   exposed-modules:
     Brick
     Brick.AttrMap
+    Brick.BChan
     Brick.Focus
     Brick.Main
     Brick.Markup
@@ -88,6 +89,7 @@ library
                        microlens-mtl,
                        vector,
                        contravariant,
+                       stm >= 2.4,
                        text,
                        text-zipper >= 0.7.1,
                        template-haskell,

--- a/programs/CustomEventDemo.hs
+++ b/programs/CustomEventDemo.hs
@@ -5,11 +5,12 @@ module Main where
 import Lens.Micro ((^.), (&), (.~), (%~))
 import Lens.Micro.TH (makeLenses)
 import Control.Monad (void, forever)
-import Control.Concurrent (newChan, writeChan, threadDelay, forkIO)
+import Control.Concurrent (threadDelay, forkIO)
 import Data.Default
 import Data.Monoid
 import qualified Graphics.Vty as V
 
+import Brick.BChan
 import Brick.Main
   ( App(..)
   , showFirstCursor
@@ -70,10 +71,10 @@ theApp =
 
 main :: IO ()
 main = do
-    chan <- newChan
+    chan <- newBChan 10
 
     forkIO $ forever $ do
-        writeChan chan Counter
+        writeBChan chan Counter
         threadDelay 1000000
 
     void $ customMain (V.mkVty def) (Just chan) theApp initialState

--- a/src/Brick/BChan.hs
+++ b/src/Brick/BChan.hs
@@ -14,22 +14,24 @@ import Control.Applicative ((<$>))
 import Control.Concurrent.STM.TBQueue
 import Control.Monad.STM (atomically, orElse)
 
+-- | @BChan@ is an abstract type representing a bounded FIFO channel.
 data BChan a = BChan (TBQueue a)
 
--- |Builds and returns a new instance of 'BChan'.
-newBChan :: Int   -- ^ maximum number of elements the queue can hold
+-- |Builds and returns a new instance of @BChan@.
+newBChan :: Int   -- ^ maximum number of elements the channel can hold
           -> IO (BChan a)
 newBChan size = atomically $ BChan <$> newTBQueue size
 
--- |Writes a value to a 'BChan'; blocks if the queue is full.
+-- |Writes a value to a @BChan@; blocks if the channel is full.
 writeBChan :: BChan a -> a -> IO ()
 writeBChan (BChan q) a = atomically $ writeTBQueue q a
 
--- |Reads the next value from the 'BChan'; blocks if necessary.
+-- |Reads the next value from the @BChan@; blocks if necessary.
 readBChan :: BChan a -> IO a
 readBChan (BChan q) = atomically $ readTBQueue q
 
--- |Reads the next value from either 'BChan'; blocks if necessary.
+-- |Reads the next value from either @BChan@, prioritizing the first @BChan@;
+-- blocks if necessary.
 readBChan2 :: BChan a -> BChan b -> IO (Either a b)
 readBChan2 (BChan q1) (BChan q2) = atomically $
   (Left <$> readTBQueue q1) `orElse` (Right <$> readTBQueue q2)

--- a/src/Brick/BChan.hs
+++ b/src/Brick/BChan.hs
@@ -1,0 +1,35 @@
+module Brick.BChan
+  ( BChan
+  , newBChan
+  , writeBChan
+  , readBChan
+  , readBChan2
+  )
+where
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>))
+#endif
+
+import Control.Concurrent.STM.TBQueue
+import Control.Monad.STM (atomically, orElse)
+
+data BChan a = BChan (TBQueue a)
+
+-- |Builds and returns a new instance of 'BChan'.
+newBChan :: Int   -- ^ maximum number of elements the queue can hold
+          -> IO (BChan a)
+newBChan size = atomically $ BChan <$> newTBQueue size
+
+-- |Writes a value to a 'BChan'; blocks if the queue is full.
+writeBChan :: BChan a -> a -> IO ()
+writeBChan (BChan q) a = atomically $ writeTBQueue q a
+
+-- |Reads the next value from the 'BChan'; blocks if necessary.
+readBChan :: BChan a -> IO a
+readBChan (BChan q) = atomically $ readTBQueue q
+
+-- |Reads the next value from either 'BChan'; blocks if necessary.
+readBChan2 :: BChan a -> BChan b -> IO (Either a b)
+readBChan2 (BChan q1) (BChan q2) = atomically $
+  (Left <$> readTBQueue q1) `orElse` (Right <$> readTBQueue q2)


### PR DESCRIPTION
#106

In `readBrickEvent` I'm currently prioritizing user events over vty events. I think this means that vty event processing can get starved by user event processing. Is this OK or do you think I should switch the priority (by flipping the argument order) or try to not always prefer one side?