### PR TITLE
Fix a small rst rendering issue

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -304,7 +304,7 @@ Using Your Own Event Type
 
 Since we often need to communicate application-specific events beyond
 Vty input events to the event handler, brick supports embedding your
-application's custom events in the stream of ``BrickEvent``s that
+application's custom events in the stream of ``BrickEvent``-s that
 your handler will receive. The type of these events is the type ``e``
 mentioned in ``BrickEvent n e`` and ``App s e n``.
 


### PR DESCRIPTION
Fixed width inline markups runs for longer than intended:

![_005](https://user-images.githubusercontent.com/185443/32362682-8ac2a750-c06b-11e7-82bd-7d952e8f2e23.png)

Because according to rst spec:

The end-string must end a text block (end of document or followed by a blank line) or be immediately followed by whitespace or any of ' " . , : ; ! ? - ) ] } / \ or >.