### PR TITLE
Fix for the "Invalid style: reversevideo" error

### DIFF
--- a/src/Brick/Themes.hs
+++ b/src/Brick/Themes.hs
@@ -223,7 +223,7 @@ allStyles :: [(T.Text, Style)]
 allStyles =
     [ ("standout", standout)
     , ("underline", underline)
-    , ("reverseVideo", reverseVideo)
+    , ("reversevideo", reverseVideo)
     , ("blink", blink)
     , ("dim", dim)
     , ("bold", bold)


### PR DESCRIPTION
Parser wouldn't find a `reverseVideo` style by name because of the `T.toLower`