### PR TITLE
Add accessor documentation for list widget

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -9,7 +9,7 @@
 -- | This module provides a scrollable list type and functions for
 -- manipulating and rendering it.
 module Brick.Widgets.List
-  ( List(listElements, listSelected, listName, listItemHeight)
+  ( List
 
   -- * Constructing a list
   , list
@@ -27,6 +27,13 @@ module Brick.Widgets.List
   , listNameL
   , listItemHeightL
 
+  -- * Accessors
+  , listElements
+  , listName
+  , listSelectedElement
+  , listSelected
+  , listItemHeight
+
   -- * Manipulating a list
   , listMoveBy
   , listMoveTo
@@ -38,7 +45,6 @@ module Brick.Widgets.List
   , listInsert
   , listRemove
   , listReplace
-  , listSelectedElement
   , listClear
   , listReverse
   , listModify
@@ -78,9 +84,13 @@ import Brick.AttrMap
 --   list
 data List n e =
     List { listElements :: !(V.Vector e)
+         -- ^ Return the list's vector of elements.
          , listSelected :: !(Maybe Int)
+         -- ^ Return the list's selected element index, if any.
          , listName :: n
+         -- ^ Return the list's name.
          , listItemHeight :: Int
+         -- ^ Return the height of the list items.
          } deriving (Functor, Foldable, Traversable, Show)
 
 suffixLenses ''List


### PR DESCRIPTION
I specifically wanted to add `listElements` to the haddock documentation, but have added the other fields for completeness.