### PR TITLE
Set list selection on move when previous selection was Nothing

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -1,5 +1,5 @@
 name:                brick
-version:             0.36.3
+version:             0.36.4
 synopsis:            A declarative terminal user interface library
 description:
   Write terminal applications painlessly with 'brick'! You write an

--- a/brick.cabal
+++ b/brick.cabal
@@ -1,5 +1,5 @@
 name:                brick
-version:             0.36.4
+version:             0.36.3
 synopsis:            A declarative terminal user interface library
 description:
   Write terminal applications painlessly with 'brick'! You write an

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -306,18 +306,23 @@ listMoveByPages pages theList = do
           in
             return $ listMoveBy nElems theList
 
--- | Move the list selected index by the specified amount, subject to
--- validation.
+-- | Move the list selected index. If the index is `Just x`, adjust by the
+-- specified amount; if it is `Nothing` (i.e. there is no selection) and the
+-- direction is positive, set to `Just 0` (first element), otherwise set to
+-- `Just (length - 1)` (last element). Subject to validation.
 listMoveBy :: Int -> List n e -> List n e
 listMoveBy amt l =
-    let newSel = clamp 0 (V.length (l^.listElementsL) - 1) <$> (amt +) <$> current
+    let current = case l^.listSelectedL of
+          Nothing
+            | amt > 0 -> Just 0
+            | otherwise -> Just (V.length (l^.listElementsL) - 1)
+          current -> current
+        clamp' a b c
+          | a <= b = Just (clamp a b c)
+          | otherwise = Nothing
+        newSel = clamp' 0 (V.length (l^.listElementsL) - 1) =<< (amt +) <$> current
     in l & listSelectedL .~ newSel
-  where
-    current = case l^.listSelectedL of
-      Nothing
-        | amt > 0 -> Just 0
-        | otherwise -> Just (V.length (l^.listElementsL) - 1)
-      current -> current
+
 
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -310,8 +310,14 @@ listMoveByPages pages theList = do
 -- validation.
 listMoveBy :: Int -> List n e -> List n e
 listMoveBy amt l =
-    let newSel = clamp 0 (V.length (l^.listElementsL) - 1) <$> (amt +) <$> (l^.listSelectedL)
+    let newSel = clamp 0 (V.length (l^.listElementsL) - 1) <$> (amt +) <$> current
     in l & listSelectedL .~ newSel
+  where
+    current = case l^.listSelectedL of
+      Nothing
+        | amt > 0 -> Just 0
+        | otherwise -> Just (V.length (l^.listElementsL) - 1)
+      current -> current
 
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -323,7 +323,6 @@ listMoveBy amt l =
         newSel = clamp' 0 (V.length (l^.listElementsL) - 1) =<< (amt +) <$> current
     in l & listSelectedL .~ newSel
 
-
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.
 listMoveTo :: Int -> List n e -> List n e


### PR DESCRIPTION
Currently, when the selected element in a list is set to `Nothing` moving up or down is impossible. This PR fixes this by setting the selection to the first element if the move direction is positive (i.e. down), otherwise it's set to the last element.