### PR TITLE
Relax upper version bound for base to support GHC 8.6.1

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -86,7 +86,7 @@ library
     Brick.Types.Internal
     Brick.Widgets.Internal
 
-  build-depends:       base <= 4.11.1.0,
+  build-depends:       base <= 4.12.0.0,
                        vty >= 5.24,
                        transformers,
                        data-clist >= 0.1,


### PR DESCRIPTION
This requires https://github.com/aelve/microlens/pull/103 to be merged.