### PR TITLE
Prevent vector exception when list is too small to draw correctly

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -208,7 +208,10 @@ drawListElements foc l drawElem =
     Widget Greedy Greedy $ do
         c <- getContext
 
-        let es = V.slice start num (l^.listElementsL)
+        let es = if num <= 0
+                 then V.empty
+                 else V.slice start num (l^.listElementsL)
+
             idx = fromMaybe 0 (l^.listSelectedL)
 
             start = max 0 $ idx - numPerHeight + 1


### PR DESCRIPTION
Vector.slice throws if the index or start is out of bounds.

Adding a `min 0` to num does not work as you can end up with
 idx being out of bounds. Checking for a zero/negative `idx`
 prevents the crash.

See example at https://gist.github.com/andrevdm/83aefb448eed44a9f10764a416bd6b12
  Crashes if the window is made *tiny*, with this fix there is no crash