### PR TITLE
tests: exit with nonzero status when tests fail

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE TypeFamilies #-}
 
 import Control.Applicative
+import Data.Bool (bool)
+import System.Exit (exitFailure, exitSuccess)
+
 import Data.IMap (IMap, Run(Run))
 import Data.IntMap (IntMap)
 import Test.QuickCheck
@@ -103,5 +106,5 @@ prop_null m = IMap.null m == IntMap.null (lower m)
 
 return []
 
-main :: IO Bool
-main = $quickCheckAll
+main :: IO ()
+main = $quickCheckAll >>= bool exitFailure exitSuccess


### PR DESCRIPTION
The current 'main' has type 'IO Bool' but a return value of 'False'
does not cause the program to exit with nonzero status.  Witnessed
by the following:

  ftweedal% cat foo.hs
  main :: IO Bool
  main = putStrLn "goodbye world" *> pure False

  ftweedal% runhaskell foo.hs
  goodbye world

  ftweedal% echo $?
  0

This causes the cabal test suite to pass, even when there are
errors.  Unless you inspect the QuickCheck output carefully, you
might not notice that a test is failing.  Update 'main' to ensure
that we exit nonzero when quickCheckAll returns 'False'.