### PR TITLE
These commits address two discrepancies in list behaviour.

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -339,16 +339,14 @@ listMoveByPages pages theList = do
 -- `Just (length - 1)` (last element). Subject to validation.
 listMoveBy :: Int -> List n e -> List n e
 listMoveBy amt l =
-    let current = case l^.listSelectedL of
+    let len = length (l^.listElementsL)
+        newSel = case l^.listSelectedL of
           Nothing
-            | amt > 0 -> Just 0
-            | otherwise -> Just (V.length (l^.listElementsL) - 1)
-          cur -> cur
-        clamp' a b c
-          | a <= b = Just (clamp a b c)
-          | otherwise = Nothing
-        newSel = clamp' 0 (V.length (l^.listElementsL) - 1) =<< (amt +) <$> current
-    in l & listSelectedL .~ newSel
+            | amt > 0 -> 0
+            | otherwise -> len - 1
+          Just i -> clamp 0 (len - 1) (amt + i)
+    in
+      l & listSelectedL .~ (if len > 0 then Just newSel else Nothing)
 
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -296,7 +296,11 @@ listRemove pos l | V.null (l^.listElementsL) = l
 -- the list bounds, zero is used instead.
 listReplace :: V.Vector e -> Maybe Int -> List n e -> List n e
 listReplace es idx l =
-    let newSel = if V.null es then Nothing else clamp 0 (V.length es - 1) <$> idx
+    let
+      newSel = if V.null es then Nothing else inBoundsOrZero <$> idx
+      inBoundsOrZero i
+        | i == clamp 0 (V.length es - 1) i = i
+        | otherwise = 0
     in l & listSelectedL .~ newSel
          & listElementsL .~ es
 

--- a/tests/List.hs
+++ b/tests/List.hs
@@ -233,6 +233,19 @@ prop_replaceNoIndex ops l xs =
   in
     isNothing (listReplace v Nothing l' ^. listSelectedL)
 
+-- | Move the list selected index. If the index is `Just x`, adjust by the
+-- specified amount; if it is `Nothing` (i.e. there is no selection) and the
+-- direction is positive, set to `Just 0` (first element), otherwise set to
+-- `Just (length - 1)` (last element). Subject to validation.
+prop_moveByWhenNoSelection :: List n a -> Int -> Property
+prop_moveByWhenNoSelection l amt =
+  let
+    l' = l & listSelectedL .~ Nothing
+    len = length (l ^. listElementsL)
+    expected = if amt > 0 then 0 else len - 1
+  in
+    len > 0 ==> listMoveBy amt l' ^. listSelectedL == Just expected
+
 
 return []
 

--- a/tests/List.hs
+++ b/tests/List.hs
@@ -6,6 +6,7 @@ module List
   ) where
 
 import Data.Function (on)
+import Data.Maybe (isNothing)
 import Data.Monoid (Endo(..))
 
 import qualified Data.Vector as V
@@ -203,6 +204,34 @@ prop_moveOpsNeverChangeList ops l =
     l' = applyListOps moveOp ops l
   in
     l' ^. listElementsL == l ^. listElementsL
+
+-- If the list is empty, empty selection is used.
+-- Otherwise, if the specified selected index is not in list bounds,
+-- zero is used instead.
+prop_replaceSetIndex
+  :: (Eq a)
+  => [ListOp a] -> List n a -> [a] -> Int -> Bool
+prop_replaceSetIndex ops l xs i =
+  let
+    v = V.fromList xs
+    l' = applyListOps op ops l
+    l'' = listReplace v (Just i) l'
+    i' = clamp 0 (length v - 1) i
+    inBounds = i == i'
+  in
+    l'' ^. listSelectedL == case (null v, inBounds) of
+      (True, _) -> Nothing
+      (False, True) -> Just i
+      (False, False) -> Just 0
+
+-- Replacing with no index always clears the index
+prop_replaceNoIndex :: (Eq a) => [ListOp a] -> List n a -> [a] -> Bool
+prop_replaceNoIndex ops l xs =
+  let
+    v = V.fromList xs
+    l' = applyListOps op ops l
+  in
+    isNothing (listReplace v Nothing l' ^. listSelectedL)
 
 
 return []


### PR DESCRIPTION
`listReplace`
-------------

Haddock says that if given index is not in bounds, 0 is used.
Implementations clamps it to 0..len - 1.  The commit adds a property
test for what the haddock says, and fixes the code.

It may be that the code is correct and the doc needs changing
instead.  Let me know and I will change the test and amend the doc
instead.


`listMoveTo`
-------------

Haddock says that if no selected index, index becomes 0 if delta is
positive and `len - 1` otherwise.  The implementation instead
sets the index to `0` or `len - 1` as stated, *then applies the
delta*.  This behaviour is surprising.  For example, if no selection
and you apply `listMoveDown` or `listMoveUp`, you end up at `1` or
`len - 2` respectively.

Implementations clamps it in `0..len - 1`.  The commit adds a
property test for what the haddock says, and fixes the code.

It may be that haddock is not really correct either, and what you
really want is to move to index `(-1 + amt)` or `(len - amt)`.  So
your clarification on this is desired.

Finally, something that is not addressed by this commit: the
behaviour when `amt == 0`.  Per haddock, this would result in
selected index being `len - 1`.  This is also surprising.  I would
expect either nothing changes, or selection goes to `0`.  If you
clarify this I can also make whatever change is necessary.



Whatever changes happen here I will obviously reflect into my list
generalisation effort, too.