### PR TITLE
List: generalise over list container type

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -94,7 +94,7 @@ library
                        directory >= 1.2.5.0,
                        dlist,
                        filepath,
-                       containers,
+                       containers >= 0.5.7,
                        microlens >= 0.3.0.0,
                        microlens-th,
                        microlens-mtl,

--- a/brick.cabal
+++ b/brick.cabal
@@ -455,3 +455,5 @@ test-suite brick-tests
                        microlens,
                        vector,
                        QuickCheck
+  if impl(ghc < 8.0)
+    build-depends:     semigroups

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -67,16 +67,17 @@ where
 import Prelude hiding (reverse, splitAt)
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>),(<*>),pure)
-import Data.Foldable (Foldable)
+import Control.Applicative ((<$>), (<*>), pure, (<|>))
+import Data.Foldable (Foldable, find, toList)
 import Data.Traversable (Traversable)
-#endif
+#else
 import Control.Applicative ((<|>))
+import Data.Foldable (find, toList)
+#endif
 import Control.Monad.Trans.State (evalState, get, put)
 
 import Lens.Micro ((^.), (^?), (&), (.~), (%~), _2, _head)
 import Data.Functor (($>))
-import Data.Foldable (find, toList)
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Maybe (fromMaybe)
 import Data.Semigroup (Semigroup, (<>), sconcat)
@@ -518,7 +519,7 @@ listMoveUp = listMoveBy (-1)
 listMovePageUp
   :: (Foldable t, Splittable t, Ord n)
   => GenericList n t e -> EventM n (GenericList n t e)
-listMovePageUp theList = listMoveByPages (-1::Double) theList
+listMovePageUp = listMoveByPages (-1::Double)
 
 -- | Move the list selected index down by one. (Moves the cursor down,
 -- adds one to the index.)
@@ -541,7 +542,7 @@ listMoveDown = listMoveBy 1
 listMovePageDown
   :: (Foldable t, Splittable t, Ord n)
   => GenericList n t e -> EventM n (GenericList n t e)
-listMovePageDown theList = listMoveByPages (1::Double) theList
+listMovePageDown = listMoveByPages (1::Double)
 
 -- | Move the list selected index by some (fractional) number of pages.
 --
@@ -557,7 +558,9 @@ listMoveByPages pages theList = do
     case v of
         Nothing -> return theList
         Just vp -> let
-            nElems = round $ pages * (fromIntegral $ vp^.vpSize._2) / (fromIntegral $ theList^.listItemHeightL)
+            nElems = round $
+              pages * fromIntegral (vp^.vpSize._2)
+              / fromIntegral (theList^.listItemHeightL)
           in
             return $ listMoveBy nElems theList
 

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -10,7 +10,8 @@
 -- | This module provides a scrollable list type and functions for
 -- manipulating and rendering it.
 module Brick.Widgets.List
-  ( List
+  ( GenericList
+  , List
 
   -- * Constructing a list
   , list
@@ -56,8 +57,13 @@ module Brick.Widgets.List
   , listAttr
   , listSelectedAttr
   , listSelectedFocusedAttr
+
+  -- * Classes
+  , Splittable(..)
   )
 where
+
+import Prelude hiding (splitAt)
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>),(<*>),pure)
@@ -65,10 +71,14 @@ import Data.Foldable (Foldable)
 import Data.Traversable (Traversable)
 #endif
 import Control.Applicative ((<|>))
+import Control.Monad.Trans.State (evalState, get, put)
 
-import Lens.Micro ((^.), (&), (.~), (%~), _2)
+import Lens.Micro ((^.), (^?), (&), (.~), (%~), _2, _head)
+import Data.Functor (($>))
+import Data.Foldable (find, toList)
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
+import Data.Semigroup (Semigroup, (<>), sconcat)
 import Graphics.Vty (Event(..), Key(..), Modifier(..))
 import qualified Data.Vector as V
 import GHC.Generics (Generic)
@@ -79,16 +89,28 @@ import Brick.Widgets.Core
 import Brick.Util (clamp)
 import Brick.AttrMap
 
--- | List state. Lists have an element type 'e' that is the data stored
--- by the list.  Lists handle the following events by default:
+-- | List state. Lists have a container @t@ of element type @e@ that
+-- is the data stored by the list.  Internally, Lists handle the
+-- following events by default:
 --
 -- * Up/down arrow keys: move cursor of selected item
 -- * Page up / page down keys: move cursor of selected item by one page
 --   at a time (based on the number of items shown)
 -- * Home/end keys: move cursor of selected item to beginning or end of
 --   list
-data List n e =
-    List { listElements :: !(V.Vector e)
+--
+-- The 'List' type synonym fixes @t@ to 'V.Vector'.
+--
+-- For a container type to be usable with 'GenericList', it must
+-- have instances of 'Traversable' and 'Splittable'.  The following
+-- functions impose further constraints:
+--
+-- * 'listInsert': 'Applicative' and 'Semigroup'
+-- * 'listRemove': 'Semigroup'
+-- * 'listClear': 'Monoid'
+--
+data GenericList n t e =
+    List { listElements :: !(t e)
          -- ^ The list's vector of elements.
          , listSelected :: !(Maybe Int)
          -- ^ The list's selected element index, if any.
@@ -98,18 +120,43 @@ data List n e =
          -- ^ The height of the list items.
          } deriving (Functor, Foldable, Traversable, Show, Generic)
 
-suffixLenses ''List
+suffixLenses ''GenericList
 
-instance Named (List n e) n where
+-- | A 'Vector'-based list state
+type List n e = GenericList n V.Vector e
+
+instance Named (GenericList n t e) n where
     getName = listName
 
-handleListEvent :: (Ord n) => Event -> List n e -> EventM n (List n e)
+-- | Ordered container types that can be split at a given index.
+-- An instance of this class is required for a container type to be
+-- usable with 'GenericList'.
+class Splittable t where
+  {-# MINIMAL splitAt #-}
+
+  -- | Split at the given index.  Equivalent to @(take n xs, drop n xs)@,
+  -- therefore total.
+  splitAt :: Int -> t a -> (t a, t a)
+
+  -- | Slice the structure.  Equivalent to @(take n . drop i) xs@,
+  -- therefore total.
+  slice :: Int {- ^ start index -} -> Int {- ^ length -} -> t a -> t a
+  slice i n = fst . splitAt n . snd . splitAt i
+
+-- | /O(1)/ 'splitAt'.
+instance Splittable V.Vector where
+  splitAt = V.splitAt
+
+
+handleListEvent
+  :: (Foldable t, Splittable t, Ord n)
+  => Event -> GenericList n t e -> EventM n (GenericList n t e)
 handleListEvent e theList =
     case e of
         EvKey KUp [] -> return $ listMoveUp theList
         EvKey KDown [] -> return $ listMoveDown theList
         EvKey KHome [] -> return $ listMoveTo 0 theList
-        EvKey KEnd [] -> return $ listMoveTo (V.length $ listElements theList) theList
+        EvKey KEnd [] -> return $ listMoveTo (length $ listElements theList) theList
         EvKey KPageDown [] -> listMovePageDown theList
         EvKey KPageUp [] -> listMovePageUp theList
         _ -> return theList
@@ -127,19 +174,20 @@ handleListEvent e theList =
 -- * Half Page Down (Ctrl-d)
 -- * Top            (g)
 -- * Bottom         (G)
-handleListEventVi :: (Ord n)
-                  => (Event -> List n e -> EventM n (List n e))
+handleListEventVi :: (Foldable t, Splittable t, Ord n)
+                  => (Event -> GenericList n t e
+                        -> EventM n (GenericList n t e))
                   -- ^ Fallback event handler to use if none of the vi keys
                   -- match.
                   -> Event
-                  -> List n e
-                  -> EventM n (List n e)
+                  -> GenericList n t e
+                  -> EventM n (GenericList n t e)
 handleListEventVi fallback e theList =
     case e of
         EvKey (KChar 'k') [] -> return $ listMoveUp theList
         EvKey (KChar 'j') [] -> return $ listMoveDown theList
         EvKey (KChar 'g') [] -> return $ listMoveTo 0 theList
-        EvKey (KChar 'G') [] -> return $ listMoveTo (V.length $ listElements theList) theList
+        EvKey (KChar 'G') [] -> return $ listMoveTo (length $ listElements theList) theList
         EvKey (KChar 'f') [MCtrl] -> listMovePageDown theList
         EvKey (KChar 'b') [MCtrl] -> listMovePageUp theList
         EvKey (KChar 'd') [MCtrl] -> listMoveByPages (0.5::Double) theList
@@ -160,28 +208,29 @@ listSelectedAttr = listAttr <> "selected"
 listSelectedFocusedAttr :: AttrName
 listSelectedFocusedAttr = listSelectedAttr <> "focused"
 
--- | Construct a list in terms of an element type 'e'.
-list :: n
+-- | Construct a list in terms of container 't' with element type 'e'.
+list :: (Foldable t)
+     => n
      -- ^ The list name (must be unique)
-     -> V.Vector e
+     -> t e
      -- ^ The initial list contents
      -> Int
      -- ^ The list item height in rows (all list item widgets must be
      -- this high)
-     -> List n e
+     -> GenericList n t e
 list name es h =
-    let selIndex = if V.null es then Nothing else Just 0
+    let selIndex = if null es then Nothing else Just 0
         safeHeight = max 1 h
     in List es selIndex name safeHeight
 
 -- | Turn a list state value into a widget given an item drawing
 -- function.
-renderList :: (Ord n, Show n)
+renderList :: (Traversable t, Splittable t, Ord n, Show n)
            => (Bool -> e -> Widget n)
            -- ^ Rendering function, True for the selected element
            -> Bool
            -- ^ Whether the list has focus
-           -> List n e
+           -> GenericList n t e
            -- ^ The List to be rendered
            -> Widget n
            -- ^ rendered widget
@@ -189,13 +238,13 @@ renderList drawElem = renderListWithIndex $ const drawElem
 
 -- | Like 'renderList', except the render function is also provided
 -- with the index of each element.
-renderListWithIndex :: (Ord n, Show n)
+renderListWithIndex :: (Traversable t, Splittable t, Ord n, Show n)
            => (Int -> Bool -> e -> Widget n)
            -- ^ Rendering function, taking index, and True for the
            -- selected element
            -> Bool
            -- ^ Whether the list has focus
-           -> List n e
+           -> GenericList n t e
            -- ^ The List to be rendered
            -> Widget n
            -- ^ rendered widget
@@ -203,19 +252,37 @@ renderListWithIndex drawElem foc l =
     withDefAttr listAttr $
     drawListElements foc l drawElem
 
-drawListElements :: (Ord n, Show n) => Bool -> List n e -> (Int -> Bool -> e -> Widget n) -> Widget n
+
+imap :: (Traversable t) => (Int -> a -> b) -> t a -> t b
+imap f xs =
+  evalState (traverse (\a -> get >>= \i -> put (i + 1) $> f i a) xs) 0
+
+
+-- | Draws the list elements.
+--
+-- Evaluates the underlying container up to, and a bit beyond, the
+-- selected element.  The exact amount depends on available height
+-- for drawing and 'listItemHeight'.  At most, it will evaluate up
+-- to element @(i + h + 1)@ where @i@ is the selected index and @h@
+-- is the available height.
+--
+drawListElements
+  :: (Traversable t, Splittable t, Ord n, Show n)
+  => Bool
+  -> GenericList n t e
+  -> (Int -> Bool -> e -> Widget n)
+  -> Widget n
 drawListElements foc l drawElem =
     Widget Greedy Greedy $ do
         c <- getContext
 
-        let es = if num <= 0
-                 then V.empty
-                 else V.slice start num (l^.listElementsL)
+        let
+            -- Take (numPerHeight * 2) elements, or whatever is left
+            es = slice start (numPerHeight * 2) (l^.listElementsL)
 
             idx = fromMaybe 0 (l^.listSelectedL)
 
             start = max 0 $ idx - numPerHeight + 1
-            num = min (numPerHeight * 2) (V.length (l^.listElementsL) - start)
 
             -- The number of items to show is the available height divided by
             -- the item height...
@@ -235,7 +302,7 @@ drawListElements foc l drawElem =
 
             off = start * (l^.listItemHeightL)
 
-            drawnElements = flip V.imap es $ \i e ->
+            drawnElements = flip imap es $ \i e ->
                 let j = i + start
                     isSelected = Just j == l^.listSelectedL
                     elemWidget = drawElem j isSelected e
@@ -249,34 +316,42 @@ drawListElements foc l drawElem =
 
         render $ viewport (l^.listNameL) Vertical $
                  translateBy (Location (0, off)) $
-                 vBox $ V.toList drawnElements
+                 vBox $ toList drawnElements
 
 -- | Insert an item into a list at the specified position.
-listInsert :: Int
+--
+listInsert :: (Splittable t, Applicative t, Semigroup (t e))
+           => Int
            -- ^ The position at which to insert (0 <= i <= size)
            -> e
            -- ^ The element to insert
-           -> List n e
-           -> List n e
+           -> GenericList n t e
+           -> GenericList n t e
 listInsert pos e l =
-    let safePos = clamp 0 (V.length es) pos
-        es = l^.listElementsL
+    let es = l^.listElementsL
         newSel = case l^.listSelectedL of
           Nothing -> 0
-          Just s -> if safePos <= s
+          Just s -> if pos <= s
                     then s + 1
                     else s
-        (front, back) = V.splitAt safePos es
+        (front, back) = splitAt pos es
     in l & listSelectedL .~ Just newSel
-         & listElementsL .~ (front V.++ (e `V.cons` back))
+         & listElementsL .~ sconcat (front :| [pure e, back])
 
 -- | Remove an element from a list at the specified position.
-listRemove :: Int
+--
+-- Applies 'splitAt' two times: first to split the structure at the
+-- given position, and again to remove the first element from the
+-- tail.  Consider the asymptotics of `splitAt` for the container
+-- type when using this function.  ('Data.Vector.splitAt' is *O(1)*).
+--
+listRemove :: (Splittable t, Foldable t, Semigroup (t e))
+           => Int
            -- ^ The position at which to remove an element (0 <= i < size)
-           -> List n e
-           -> List n e
-listRemove pos l | V.null (l^.listElementsL) = l
-                 | pos /= clamp 0 (V.length (l^.listElementsL) - 1) pos = l
+           -> GenericList n t e
+           -> GenericList n t e
+listRemove pos l | null (l^.listElementsL) = l
+                 | pos /= splitClamp l pos = l
                  | otherwise =
     let newSel = case l^.listSelectedL of
           Nothing -> 0
@@ -284,46 +359,60 @@ listRemove pos l | V.null (l^.listElementsL) = l
                  | pos == s -> pos - 1
                  | pos  < s -> s - 1
                  | otherwise -> s
-        (front, back) = V.splitAt pos es
-        es' = front V.++ V.tail back
+        (front, rest) = splitAt pos es
+        (_, back) = splitAt 1 rest
+        es' = front <> back
         es = l^.listElementsL
-    in l & listSelectedL .~ (if V.null es' then Nothing else Just newSel)
+    in l & listSelectedL .~ (if null es' then Nothing else Just newSel)
          & listElementsL .~ es'
 
 -- | Replace the contents of a list with a new set of elements and
 -- update the new selected index. If the list is empty, empty selection is used
 -- instead. Otherwise, if the specified selected index (via 'Just') is not in
 -- the list bounds, zero is used instead.
-listReplace :: V.Vector e -> Maybe Int -> List n e -> List n e
+--
+listReplace
+  :: (Foldable t, Splittable t)
+  => t e -> Maybe Int -> GenericList n t e -> GenericList n t e
 listReplace es idx l =
     let
-      newSel = if V.null es then Nothing else inBoundsOrZero <$> idx
+      l' = l & listElementsL .~ es
+      newSel = if null es then Nothing else inBoundsOrZero <$> idx
       inBoundsOrZero i
-        | i == clamp 0 (V.length es - 1) i = i
+        | i == splitClamp l' i = i
         | otherwise = 0
-    in l & listSelectedL .~ newSel
-         & listElementsL .~ es
+    in l' & listSelectedL .~ newSel
 
 -- | Move the list selected index up by one. (Moves the cursor up,
 -- subtracts one from the index.)
-listMoveUp :: List n e -> List n e
+listMoveUp
+  :: (Foldable t, Splittable t)
+  => GenericList n t e -> GenericList n t e
 listMoveUp = listMoveBy (-1)
 
 -- | Move the list selected index up by one page.
-listMovePageUp :: (Ord n) => List n e -> EventM n (List n e)
+listMovePageUp
+  :: (Foldable t, Splittable t, Ord n)
+  => GenericList n t e -> EventM n (GenericList n t e)
 listMovePageUp theList = listMoveByPages (-1::Double) theList
 
 -- | Move the list selected index down by one. (Moves the cursor down,
 -- adds one to the index.)
-listMoveDown :: List n e -> List n e
+listMoveDown
+  :: (Foldable t, Splittable t)
+  => GenericList n t e -> GenericList n t e
 listMoveDown = listMoveBy 1
 
 -- | Move the list selected index down by one page.
-listMovePageDown :: (Ord n) => List n e -> EventM n (List n e)
+listMovePageDown
+  :: (Foldable t, Splittable t, Ord n)
+  => GenericList n t e -> EventM n (GenericList n t e)
 listMovePageDown theList = listMoveByPages (1::Double) theList
 
 -- | Move the list selected index by some (fractional) number of pages.
-listMoveByPages :: (Ord n, RealFrac m) => m -> List n e -> EventM n (List n e)
+listMoveByPages
+  :: (Foldable t, Splittable t, Ord n, RealFrac m)
+  => m -> GenericList n t e -> EventM n (GenericList n t e)
 listMoveByPages pages theList = do
     v <- lookupViewport (theList^.listNameL)
     case v of
@@ -337,55 +426,99 @@ listMoveByPages pages theList = do
 -- specified amount; if it is `Nothing` (i.e. there is no selection) and the
 -- direction is positive, set to `Just 0` (first element), otherwise set to
 -- `Just (length - 1)` (last element). Subject to validation.
-listMoveBy :: Int -> List n e -> List n e
+listMoveBy
+  :: (Foldable t, Splittable t)
+  => Int -> GenericList n t e -> GenericList n t e
 listMoveBy amt l =
     let len = length (l^.listElementsL)
         newSel = case l^.listSelectedL of
           Nothing
             | amt > 0 -> 0
             | otherwise -> len - 1
-          Just i -> clamp 0 (len - 1) (amt + i)
+          Just i -> splitClamp l (amt + i)
     in
       l & listSelectedL .~ (if len > 0 then Just newSel else Nothing)
 
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.
-listMoveTo :: Int -> List n e -> List n e
+--
+-- If @pos >= 0@, indexes from the start of the list (which gets
+-- evaluated up to the target index)
+--
+-- If @pos < 0@, indexes from the end of the list (which evalutes
+-- 'length' of the list).
+--
+listMoveTo
+  :: (Foldable t, Splittable t)
+  => Int -> GenericList n t e -> GenericList n t e
 listMoveTo pos l =
-    let len = V.length (l^.listElementsL)
-        newSel = clamp 0 (len - 1) $ if pos < 0 then len - pos else pos
-    in l & listSelectedL .~ if len > 0
+  let
+    len = length (l ^. listElementsL)
+    i = if pos < 0 then len - pos else pos
+    newSel = splitClamp l i
+  in l & listSelectedL .~ if not (null (l ^. listElementsL))
                             then Just newSel
                             else Nothing
 
+-- | Split-based clamp that avoids evaluating 'length' of the
+-- structure (unless the structure is already fully evaluated).
+--
+splitClamp :: (Foldable t, Splittable t) => GenericList n t e -> Int -> Int
+splitClamp l i =
+  let
+    (_, t) = splitAt i (l ^. listElementsL)  -- split at i
+  in
+    -- If the tail is empty, then the requested index is not in the list.
+    -- And because we have already seen the end of the list, using 'length'
+    -- will not force unwanted computation.
+    --
+    -- Otherwise if tail is not empty, then we already know that i
+    -- is in the list, so we don't need to know the length
+    clamp 0 (if null t then length (l ^. listElementsL) - 1 else i) i
+
 -- | Set the selected index for a list to the index of the specified
 -- element if it is in the list, or leave the list unmodified otherwise.
-listMoveToElement :: (Eq e) => e -> List n e -> List n e
+listMoveToElement
+  :: (Eq e, Traversable t)
+  => e -> GenericList n t e -> GenericList n t e
 listMoveToElement e l =
-    let i = V.elemIndex e (l^.listElementsL)
+    let i = fmap fst $ find ((== e) . snd) $ imap (,) (l^.listElementsL)
     in l & listSelectedL %~ (i <|>)
 
 -- | Return a list's selected element, if any.
-listSelectedElement :: List n e -> Maybe (Int, e)
+--
+-- Only evaluates as much of the container as needed.
+--
+-- Complexity: same as 'splitAt' for the container type.
+--
+listSelectedElement
+  :: (Splittable t, Foldable t)
+  => GenericList n t e -> Maybe (Int, e)
 listSelectedElement l = do
   sel <- l^.listSelectedL
-  return (sel, (l^.listElementsL) V.! sel)
+  let (_, xs) = splitAt sel (l ^. listElementsL)
+  (sel,) <$> toList xs ^? _head
 
 -- | Remove all elements from the list and clear the selection.
-listClear :: List n e -> List n e
-listClear l = l & listElementsL .~ V.empty & listSelectedL .~ Nothing
+listClear :: (Monoid (t e)) => GenericList n t e -> GenericList n t e
+listClear l = l & listElementsL .~ mempty & listSelectedL .~ Nothing
 
 -- | Reverse the list.  The element selected before the reversal will
 -- again be the selected one.
+--
+-- For now, this is only implemented for 'Vector'-based lists.
+--
 listReverse :: List n e -> List n e
 listReverse theList = theList & listElementsL %~ V.reverse & listSelectedL .~ newSel
-  where n = V.length (listElements theList)
+  where n = length (listElements theList)
         newSel = (-) <$> pure (n-1) <*> listSelected theList
 
 -- | Apply a function to the selected element. If no element is selected
 -- the list is not modified.
-listModify :: (e -> e) -> List n e -> List n e
-listModify f l = case listSelectedElement l of
+--
+-- /O(n)/
+--
+listModify :: (Traversable t) => (e -> e) -> GenericList n t e -> GenericList n t e
+listModify f l = case l ^. listSelectedL of
   Nothing -> l
-  Just (n,e) -> let es = V.update (l^.listElementsL) (return (n, f e))
-                in listReplace es (Just n) l
+  Just j -> l & listElementsL %~ imap (\i e -> if i == j then f e else e)

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -585,14 +585,13 @@ listMoveBy
   :: (Foldable t, Splittable t)
   => Int -> GenericList n t e -> GenericList n t e
 listMoveBy amt l =
-    let len = length (l^.listElementsL)
-        newSel = case l^.listSelectedL of
+    let target = case l ^. listSelectedL of
           Nothing
             | amt > 0 -> 0
-            | otherwise -> len - 1
-          Just i -> splitClamp l (amt + i)
+            | otherwise -> length (l ^. listElementsL) - 1
+          Just i -> max 0 (amt + i)  -- don't be negative
     in
-      l & listSelectedL .~ (if len > 0 then Just newSel else Nothing)
+      listMoveTo target l
 
 -- | Set the selected index for a list to the specified index, subject
 -- to validation.

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -79,6 +79,7 @@ import Data.Foldable (find, toList)
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Maybe (fromMaybe)
 import Data.Semigroup (Semigroup, (<>), sconcat)
+import qualified Data.Sequence as Seq
 import Graphics.Vty (Event(..), Key(..), Modifier(..))
 import qualified Data.Vector as V
 import GHC.Generics (Generic)
@@ -140,12 +141,21 @@ class Splittable t where
 
   -- | Slice the structure.  Equivalent to @(take n . drop i) xs@,
   -- therefore total.
+  --
+  -- The default implementation applies 'splitAt' two times: first
+  -- to drop elements leading up to the slice, and again to drop
+  -- elements after the slice.
+  --
   slice :: Int {- ^ start index -} -> Int {- ^ length -} -> t a -> t a
   slice i n = fst . splitAt n . snd . splitAt i
 
 -- | /O(1)/ 'splitAt'.
 instance Splittable V.Vector where
   splitAt = V.splitAt
+
+-- | /O(log(min(i,n-i)))/ 'splitAt'.
+instance Splittable Seq.Seq where
+  splitAt = Seq.splitAt
 
 
 handleListEvent

--- a/tests/List.hs
+++ b/tests/List.hs
@@ -14,6 +14,7 @@ import Data.Maybe (isNothing)
 import Data.Monoid (Endo(..))
 import Data.Semigroup (Semigroup((<>)))
 
+import qualified Data.Sequence as Seq
 import qualified Data.Vector as V
 import Lens.Micro
 import Test.QuickCheck
@@ -271,6 +272,12 @@ prop_splitAtLength_Vector = splitAtLength . V.fromList
 
 prop_splitAtAppend_Vector :: (Eq a) => [a] -> Int -> Bool
 prop_splitAtAppend_Vector = splitAtAppend . V.fromList
+
+prop_splitAtLength_Seq :: [a] -> Int -> Bool
+prop_splitAtLength_Seq = splitAtLength . Seq.fromList
+
+prop_splitAtAppend_Seq :: (Eq a) => [a] -> Int -> Bool
+prop_splitAtAppend_Seq = splitAtAppend . Seq.fromList
 
 
 return []

--- a/tests/List.hs
+++ b/tests/List.hs
@@ -1,13 +1,18 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module List
   (
     main
   ) where
 
+import Prelude hiding (splitAt)
+
 import Data.Function (on)
 import Data.Maybe (isNothing)
 import Data.Monoid (Endo(..))
+import Data.Semigroup (Semigroup((<>)))
 
 import qualified Data.Vector as V
 import Lens.Micro
@@ -245,6 +250,27 @@ prop_moveByWhenNoSelection l amt =
     expected = if amt > 0 then 0 else len - 1
   in
     len > 0 ==> listMoveBy amt l' ^. listSelectedL == Just expected
+
+
+splitAtLength :: (Foldable t, Splittable t) => t a -> Int -> Bool
+splitAtLength l i =
+  let
+    len = length l
+    (h, t) = splitAt i l
+  in
+    length h + length t == len
+    && length h == clamp 0 len i
+
+splitAtAppend
+  :: (Splittable t, Semigroup (t a), Eq (t a))
+  => t a -> Int -> Bool
+splitAtAppend l i = uncurry (<>) (splitAt i l) == l
+
+prop_splitAtLength_Vector :: [a] -> Int -> Bool
+prop_splitAtLength_Vector = splitAtLength . V.fromList
+
+prop_splitAtAppend_Vector :: (Eq a) => [a] -> Int -> Bool
+prop_splitAtAppend_Vector = splitAtAppend . V.fromList
 
 
 return []


### PR DESCRIPTION
Fixes: https://github.com/jtdaugherty/brick/issues/201

Changes:

```
cee1e5e (Fraser Tweedale, 2 minutes ago)
   List: apply HLint suggestions

86377f6 (Fraser Tweedale, 11 minutes ago)
   List: include simplified type signatures in haddock

   Mention the simplified type signatures when using the 'List' type synonym. 
   This should improve the readability and usefulness of the documentation.

   Also do a couple of drive-by doc cleanups and complexity assertions.

04dd905 (Fraser Tweedale, 49 minutes ago)
   List: add class Reversible

   Add the 'Reversible' type class and generalise 'listReverse' over it.  Add
   instances and QuickCheck properties for Vector and Seq.

1425ed7 (Fraser Tweedale, 2 hours ago)
   List: add instance Splittable Seq

   Add an instance of Splittable for Data.Sequence.Seq, and QuickCheck 
   properties for it.

   Add lower bound containers >= 0.5.7, being the version at which the 
   Semigroup instance was introduced.

57f0233 (Fraser Tweedale, 5 days ago)
   List: abstract container type

   Introduce 'GeneralList' which abstracts list behaviour over the container
   type.  This allows the use of types other than Vector, if it would suit a
   particular application (e.g. lazy loading of list contents).

   'List' is retained as a type synonym for backwards compatibility. For a
   container type to be usable with 'List', it must have instances of
   'Traversable' and a new type class 'Splittable' which allows splitting the
   container at a given index.

   Some operations impose additional constraints on the container type:

   - listInsert: 'Applicative' and 'Semigroup'
   - listRemove: 'Semigroup'
   - listClear: 'Monoid'

   Fixes: https://github.com/jtdaugherty/brick/issues/201
```