### PR TITLE
Remove reference to Default class from haddock

### DIFF
--- a/src/Brick/Widgets/Border/Style.hs
+++ b/src/Brick/Widgets/Border/Style.hs
@@ -10,8 +10,7 @@
 --
 -- To use these in your widgets, see
 -- 'Brick.Widgets.Core.withBorderStyle'. By default, widgets rendered
--- without a specified border style use 'unicode' via the 'Default'
--- instance provided by 'BorderStyle'.
+-- without a specified border style use 'unicode' style.
 module Brick.Widgets.Border.Style
   ( BorderStyle(..)
   , borderStyleFromChar


### PR DESCRIPTION
Dependency on data-default was removed in https://github.com/jtdaugherty/brick/commit/4a2b90eae7df9b98999c8134524fc61684a9429e#diff-e76c22dbfcd22ba94982edf2323e9024, so removing the outdated mention of the class from the docs as well.