### PR TITLE
Add brick-filetree to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Feature Overview
  * Type-safe, validated input form API (see the `Brick.Forms` module)
  * A filesystem browser for file and directory selection
  * Borders can be configured to automatically connect!
+ 
+Additional Packages
+-------------------
+
+The following packages contain additional functionality which extends `brick`
+
+ * [`brick-filetree`](https://github.com/ChrisPenner/brick-filetree) [[Hackage]](http://hackage.haskell.org/package/brick-filetree) - Interactively explore a file tree selecting or flagging files and directories
 
 Brick-Users Discussion
 ----------------------


### PR DESCRIPTION
Lib is usable now 😄 

I figured it makes sense to have a README section for libs which extend brick; let me know if there's a different spot to put it instead 🤷‍♂️ 