### PR TITLE
add test for List initial selection

### DIFF
--- a/tests/List.hs
+++ b/tests/List.hs
@@ -98,6 +98,13 @@ applyListOps
   => (op a -> List n a -> List n a) -> t (op a) -> List n a -> List n a
 applyListOps f = appEndo . foldMap (Endo . f)
 
+
+-- | Initial selection is always 0 (or Nothing for empty list)
+prop_initialSelection :: [a] -> Bool
+prop_initialSelection xs =
+  list () (V.fromList xs) 1 ^. listSelectedL ==
+    if null xs then Nothing else Just 0
+
 -- list operations keep the selected index in bounds
 prop_listOpsMaintainSelectedValid
   :: (Eq a) => [ListOp a] -> List n a -> Bool


### PR DESCRIPTION
We do not have a test to confirm that the initial selection for a
list is always 'Just 0' (or 'Nothing' when the list is empty).  Add
a test for this contract.