### PR TITLE
add Splittable instance for []

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -99,6 +99,7 @@ import Brick.Main (lookupViewport)
 import Brick.Widgets.Core
 import Brick.Util (clamp)
 import Brick.AttrMap
+import qualified Data.List as L
 
 -- | List state. Lists have a container @t@ of element type @e@ that is
 -- the data stored by the list. Internally, Lists handle the following
@@ -168,6 +169,9 @@ instance Splittable V.Vector where
 -- | /O(log(min(i,n-i)))/ 'splitAt'.
 instance Splittable Seq.Seq where
     splitAt = Seq.splitAt
+
+instance Splittable [] where
+    splitAt = L.splitAt
 
 -- | Ordered container types where the order of elements can be
 -- reversed. Only required if you want to use 'listReverse'.


### PR DESCRIPTION
I noticed this was missing. I understand that the performance is quite bad, but it's valuable for quick debugging things with `brick`.

Thanks for the lovely library :)

I am curious as to why this instance did not exist already: Is it because it was seen as too expensive / prone to correctness issues (eg. someone feeding an infinite list)?