### PR TITLE
Fixed the Cache demo program

### DIFF
--- a/programs/CacheDemo.hs
+++ b/programs/CacheDemo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 


### PR DESCRIPTION
The `CacheDemo.hs` file was missing the CPP language extension. Thanks for the great package! :)