### PR TITLE
New initialRenderState function

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": "bash",
+      "args": ["-lc", "cabal new-build && echo 'Done'"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "haskell",
+        "fileLocation": "relative",
+        "pattern": [
+          {
+            "regexp": "^(.+?):(\\d+):(\\d+):\\s+(error|warning|info):.*$",
+            "file": 1, "line": 2, "column": 3, "severity": 4
+          },
+          {
+            "regexp": "\\s*(.*)$",
+            "message": 1
+          }
+        ]
+      },
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
+      "label": "Test",
+      "type": "shell",
+      "command": "bash",
+      "args": ["-lc", "cabal new-test --enable-tests --test-show-details=direct && echo 'Done'"],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "haskell",
+        "fileLocation": "relative",
+        "pattern": [
+          {
+            "regexp": "^(.+?):(\\d+):(\\d+):.*$",
+            "file": 1, "line": 2, "column": 3, "severity": 4
+          },
+          {
+            "regexp": "\\s*(\\d\\)\\s)?(.*)$",
+            "message": 2
+          }
+        ]
+      },
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    }
+  ]
+}

--- a/src/Brick/Types.hs
+++ b/src/Brick/Types.hs
@@ -78,6 +78,7 @@ module Brick.Types
 
   -- * Renderer internals (for benchmarking)
   , RenderState
+  , initialRenderState
   )
 where
 

--- a/src/Brick/Types/Internal.hs
+++ b/src/Brick/Types/Internal.hs
@@ -15,6 +15,7 @@ module Brick.Types.Internal
   , Viewport(..)
   , ViewportType(..)
   , RenderState(..)
+  , initialRenderState
   , Direction(..)
   , CursorLocation(..)
   , cursorLocationL
@@ -253,6 +254,9 @@ data RenderState n =
        , renderCache :: M.Map n (Result n)
        , clickableNames :: [n]
        } deriving (Read, Show, Generic, NFData)
+
+initialRenderState :: RenderState n
+initialRenderState = RS M.empty [] S.empty M.empty []
 
 data EventRO n = EventRO { eventViewportMap :: M.Map n Viewport
                          , eventVtyHandle :: Vty


### PR DESCRIPTION
Trying to update https://github.com/lspitzner/bricki-reflex to work with `ghc-8.6.5` and need this export since the `RenderState` constructor is internal and hidden.