### PR TITLE
Fix directories not showing up with fileExtensionMatch

### DIFF
--- a/src/Brick/Widgets/FileBrowser.hs
+++ b/src/Brick/Widgets/FileBrowser.hs
@@ -778,5 +778,6 @@ fileTypeMatch tys i = maybe False (`elem` tys) $ fileInfoFileType i
 -- argument of @"xml"@ would match regular files @test.xml@ and
 -- @TEST.XML@ and it will match directories regardless of name.
 fileExtensionMatch :: String -> FileInfo -> Bool
-fileExtensionMatch ext i =
-    ('.' : (toLower <$> ext)) `isSuffixOf` (toLower <$> fileInfoFilename i)
+fileExtensionMatch ext i = case fileInfoFileType i of
+    Just RegularFile -> ('.' : (toLower <$> ext)) `isSuffixOf` (toLower <$> fileInfoFilename i)
+    _ -> True

--- a/src/Brick/Widgets/FileBrowser.hs
+++ b/src/Brick/Widgets/FileBrowser.hs
@@ -779,5 +779,10 @@ fileTypeMatch tys i = maybe False (`elem` tys) $ fileInfoFileType i
 -- @TEST.XML@ and it will match directories regardless of name.
 fileExtensionMatch :: String -> FileInfo -> Bool
 fileExtensionMatch ext i = case fileInfoFileType i of
+    Just Directory -> True
     Just RegularFile -> ('.' : (toLower <$> ext)) `isSuffixOf` (toLower <$> fileInfoFilename i)
-    _ -> True
+    Just SymbolicLink -> case fileInfoLinkTargetType i of
+        Nothing -> error "impossible"
+        Just Directory -> True
+        _ -> False
+    _ -> False

--- a/src/Brick/Widgets/FileBrowser.hs
+++ b/src/Brick/Widgets/FileBrowser.hs
@@ -782,7 +782,6 @@ fileExtensionMatch ext i = case fileInfoFileType i of
     Just Directory -> True
     Just RegularFile -> ('.' : (toLower <$> ext)) `isSuffixOf` (toLower <$> fileInfoFilename i)
     Just SymbolicLink -> case fileInfoLinkTargetType i of
-        Nothing -> error "impossible"
         Just Directory -> True
         _ -> False
     _ -> False


### PR DESCRIPTION
The fileExtensionMatch function is described as:
>A filter that matches any directory regardless of name, or any regular file with the specified extension.

The first part doesn't seem to work, only files with the specified extension show up. This pull request should fix it.

Love the library and documentation by the way, thanks for your work.