### PR TITLE
Defer to horizontal widget size in `vLimitPercent`

### DIFF
--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -807,7 +807,7 @@ vLimit h p =
 -- defers to the limited widget horizontally.
 vLimitPercent :: Int -> Widget n -> Widget n
 vLimitPercent h' p =
-    Widget (vSize p) Fixed $ do
+    Widget (hSize p) Fixed $ do
       let h = clamp 0 100 h'
       ctx <- getContext
       let usableHeight = ctx^.availHeightL


### PR DESCRIPTION
I came across this small mistake by chance.