### PR TITLE
Support Home and End keys in the editor

### DIFF
--- a/src/Brick/Widgets/Edit.hs
+++ b/src/Brick/Widgets/Edit.hs
@@ -124,6 +124,8 @@ handleEditorEvent e ed =
                   EvKey KLeft [] -> Z.moveLeft
                   EvKey KRight [] -> Z.moveRight
                   EvKey KBS [] -> Z.deletePrevChar
+                  EvKey KHome [] -> Z.gotoBOL
+                  EvKey KEnd [] -> Z.gotoEOL
                   _ -> id
         in return $ applyEdit f ed
 


### PR DESCRIPTION
This adds handlers to support pressing Home and End keys to jump to the
beginning as well as the end. The keys are typically supported by almost
all text input widgets and now provided by Brick as well.