### PR TITLE
RFC export current entry selection function

### DIFF
--- a/src/Brick/Widgets/FileBrowser.hs
+++ b/src/Brick/Widgets/FileBrowser.hs
@@ -67,6 +67,7 @@ module Brick.Widgets.FileBrowser
 
   -- * Handling events
   , handleFileBrowserEvent
+  , maybeSelectCurrentEntry
 
   -- * Rendering
   , renderFileBrowser


### PR DESCRIPTION
I'd like to move Purebred to use the Brick file browser. We used to write our own when Brick hasn't had one, but it would be foolish to maintain our own.

One missing function from the public API in Brick I'm missing is the function which handles the default state I can fall back to. That is, setting a new working directory by entering a selected directory or following symlinks. I could replicate this, but I think I would be repeating myself.

Background motivation is, that in Purebred we attach files by selecting them. We use a different word to refer what Brick uses as a selection. We call it "toggling". So a user in Purebred toggles all files to be attached first, then selects the last file which turn Purebred into attaching what is toggled **and** selected (saves an additional key stroke).

I'd be happy to add a little haddock string and update the pull request if you'd be happy to accept the change.