### PR TITLE
Add window width/height to Context

### DIFF
--- a/src/Brick/Types.hs
+++ b/src/Brick/Types.hs
@@ -33,10 +33,12 @@ module Brick.Types
   , getContext
 
   -- ** The rendering context
-  , Context(ctxAttrName, availWidth, availHeight, ctxBorderStyle, ctxAttrMap, ctxDynBorders)
+  , Context(ctxAttrName, availWidth, availHeight, windowWidth, windowHeight, ctxBorderStyle, ctxAttrMap, ctxDynBorders)
   , attrL
   , availWidthL
   , availHeightL
+  , windowWidthL
+  , windowHeightL
   , ctxAttrMapL
   , ctxAttrNameL
   , ctxBorderStyleL

--- a/src/Brick/Types/Internal.hs
+++ b/src/Brick/Types/Internal.hs
@@ -268,6 +268,8 @@ data Context =
     Context { ctxAttrName :: AttrName
             , availWidth :: Int
             , availHeight :: Int
+            , windowWidth :: Int
+            , windowHeight :: Int
             , ctxBorderStyle :: BorderStyle
             , ctxAttrMap :: AttrMap
             , ctxDynBorders :: Bool

--- a/src/Brick/Widgets/Internal.hs
+++ b/src/Brick/Widgets/Internal.hs
@@ -35,7 +35,7 @@ renderFinal aMap layerRenders sz chooseCursor rs = (newRS, picWithBg, theCursor,
         (layerResults, !newRS) = flip runState rs $ sequence $
             (\p -> runReaderT p ctx) <$>
             (render <$> cropToContext <$> layerRenders)
-        ctx = Context mempty (fst sz) (snd sz) defaultBorderStyle aMap False
+        ctx = Context mempty (fst sz) (snd sz) (fst sz) (snd sz) defaultBorderStyle aMap False
         pic = V.picForLayers $ uncurry V.resize sz <$> (^.imageL) <$> layerResults
         -- picWithBg is a workaround for runaway attributes.
         -- See https://github.com/coreyoconnor/vty/issues/95


### PR DESCRIPTION
Motivation: `vLimitPercent`/`hLimitPercent` are useful functions, but they leave something to be desired when using them inside a large viewport because they use the "available height." In a viewport, this is a large number and not what I want when I'm designing a UI. (In my experiments it was like 999995? Not sure why.)

I want to render a list of items inside a viewport, and have each item's height constrained to 30% of the total window height. After this PR I can write `vLimitPercentWindow` like this:

```haskell
vLimitPercentWindow :: Int -> Widget n -> Widget n
vLimitPercentWindow h' p =
  Widget (hSize p) Fixed $ do
    let h = clamp 0 100 h'
    ctx <- getContext
    let usableHeight = ctx ^. windowHeightL
    let widgetHeight = round (toRational usableHeight * (toRational h / 100))
    withReaderT (availHeightL %~ (min widgetHeight)) $ render $ cropToContext p
```