### PR TITLE
Add a lens into form state

### DIFF
--- a/src/Brick/Forms.hs
+++ b/src/Brick/Forms.hs
@@ -50,6 +50,7 @@ module Brick.Forms
   , newForm
   , formFocus
   , formState
+  , formStateLens
   , handleFormEvent
   , renderForm
   , renderFormFieldState
@@ -207,6 +208,14 @@ data Form s e n =
          , formConcatAll :: [Widget n] -> Widget n
          -- ^ Concatenation function for this form's field renderings.
          }
+
+-- | A lens into the formState of a form.
+--
+-- This could be useful if you want to preseve focus properties, etc.
+-- of your form but need to modify the underlying application state.
+
+formStateLens :: Lens' (Form s e n) s
+formStateLens = lens formState (\f s -> f { formState = s })
 
 -- | Compose a new rendering augmentation function with the one in the
 -- form field collection. For example, we might put a label on the left


### PR DESCRIPTION
I've found that I've had to write a fair bit of boilerplate to rebuild my form after extracting the state for modifications. It would be convenient if the Form fields were also lenses, but especially the state field.

This seems to make sense to me as well since the state itself often requires lenses to be used in form fields, so it's nicely composable if a lens exists for the state.

Let me know if this doesn't make sense for some reason! I've only been using Brick for a brief amount of time.