### PR TITLE
Update constraint on base for build with ghc-9.0

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -113,7 +113,7 @@ library
     Brick.Types.Internal
     Brick.Widgets.Internal
 
-  build-depends:       base <= 4.14.1.0,
+  build-depends:       base <= 4.15,
                        vty >= 5.31,
                        transformers,
                        data-clist >= 0.1,


### PR DESCRIPTION
Brick build works withouts problems with upcoming ghc-9.0.1+ and base-4.15.0.0