### PR TITLE
`forceAttr` doesn't force style

### DIFF
--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -862,7 +862,8 @@ updateAttrMap f p =
 
 -- | When rendering the specified widget, force all attribute lookups
 -- in the attribute map to use the value currently assigned to the
--- specified attribute name.
+-- specified attribute name. Note that it will still inherit from the
+-- default attribute. To override that as well, use 'modifyDefAttr'.
 forceAttr :: AttrName -> Widget n -> Widget n
 forceAttr an p =
     Widget (hSize p) (vSize p) $ do


### PR DESCRIPTION
I'm trying to make a list with some separators, and the best way I can think to implement that is by just adding a `hBorder` under specific elements. However, when these elements are highlighted, so is the border. Looking through the issues, I found #216, but the solution there only seems to work because the selected attribute is a change in the colours. In my real use case, the list element has several colours in it, so I want to use `Vty.reverseVideo` as my selection attribute, which persists on the border. Attached below is a `Main.hs` you can use to see what I mean.

I haven't been able to get this to work, even by trying to set `listAttr` to ` Vty.withStyle Vty.defAttr Vty.defaultStyleMask` to try and force the default style. I think this is due to the fact that `withStyle` merges the styles with bitwise or, and the `defAttr`, which is set to be `listSelectedAttr`, just overrides the default style. Setting `listAttr` to `Vty.withStyle (fg Vty.white) Vty.defaultStyleMask)` doesn't work either.

As always, thanks for this great library!

```haskell

{-# LANGUAGE OverloadedStrings #-}
{-# LANGUAGE CPP #-}
module Main where

import Control.Monad (void)
import Data.Maybe (fromMaybe)
#if !(MIN_VERSION_base(4,11,0))
import Data.Monoid
#endif
import qualified Graphics.Vty as V
import Lens.Micro ((^.))

import qualified Brick.AttrMap as A
import qualified Brick.Main as M
import Brick.Types (Widget)
import qualified Brick.Types as T
import Brick.Util (fg, on)
import qualified Brick.Widgets.Border as B
import qualified Brick.Widgets.Center as C
import Brick.Widgets.Core (hLimit, str, vBox, vLimit, withAttr, forceAttr, (<+>), (<=>))
import qualified Brick.Widgets.List as L
import qualified Data.Vector as Vec

drawUI :: (Show a) => L.List () a -> [Widget ()]
drawUI l = [ui]
    where
        box = B.border  $
              hLimit 25 $
              vLimit 15 $
              L.renderListWithIndex listDrawElement True l
        ui =  C.vCenter $ vBox [ C.hCenter box
                              , str " "
                              , C.hCenter $ str "Press j/k to move."
                              , C.hCenter $ str "Press Esc to exit."
                              ]


appEvent :: L.List () Char -> T.BrickEvent () e -> T.EventM () (T.Next (L.List () Char))
appEvent l (T.VtyEvent e) =
    case e of
        V.EvKey V.KEsc [] -> M.halt l

        ev -> M.continue =<< (L.handleListEventVi L.handleListEvent) ev l
    where
appEvent l _ = M.continue l

listDrawElement :: (Show a) => Int -> Bool -> a -> Widget ()
listDrawElement i sel a =
   C.hCenter $ if i == 0
        then
          (C.hCenter (str "Item " <+> (str $ show a))) <=> (forceAttr L.listAttr B.hBorder)
        else (str "Item " <+> (str $ show a))

initialState :: L.List () Char
initialState = L.list () (Vec.fromList ['a','b','c']) 1

theMap :: A.AttrMap
theMap = A.attrMap V.defAttr
    [ (L.listAttr,            fg V.white)
    , (L.listSelectedAttr,    V.withStyle V.defAttr V.reverseVideo)
    ]

theApp :: M.App (L.List () Char) e ()
theApp =
    M.App { M.appDraw = drawUI
          , M.appChooseCursor = M.showFirstCursor
          , M.appHandleEvent = appEvent
          , M.appStartEvent = return
          , M.appAttrMap = const theMap
          }

main :: IO ()
main = void $ M.defaultMain theApp initialState
```