### PR TITLE
Suggestion: add Filterable (and Witherable) instances for GenericList

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -135,7 +135,8 @@ library
                        deepseq >= 1.3 && < 1.5,
                        unix,
                        bytestring,
-                       word-wrap >= 0.2
+                       word-wrap >= 0.2,
+                       witherable-class
   if impl(ghc < 8.0)
     build-depends:     semigroups
 

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -73,7 +73,7 @@ module Brick.Widgets.List
   )
 where
 
-import Prelude hiding (reverse, splitAt)
+import Prelude hiding (reverse, splitAt, filter)
 
 import Control.Applicative ((<|>))
 #if !MIN_VERSION_base(4,8,0)
@@ -97,6 +97,7 @@ import qualified Data.Sequence as Seq
 import Graphics.Vty (Event(..), Key(..), Modifier(..))
 import qualified Data.Vector as V
 import GHC.Generics (Generic)
+import qualified Data.Witherable.Class as W
 
 import Brick.Types
 import Brick.Main (lookupViewport)
@@ -145,6 +146,11 @@ type List n e = GenericList n V.Vector e
 
 instance Named (GenericList n t e) n where
     getName = listName
+
+instance W.Filterable t => W.Filterable (GenericList n t) where
+  catMaybes l = l & listElementsL %~ W.catMaybes
+
+instance (Traversable t, W.Filterable t) => W.Witherable (GenericList n t) where
 
 -- | Ordered container types that can be split at a given index. An
 -- instance of this class is required for a container type to be usable


### PR DESCRIPTION
This entails adding [witherable-class](https://hackage.haskell.org/package/witherable-class) as a dependency.

If you are unaware, this is a package that introduces the typeclass `Filterable` that polymorphises the function `filter`, and introduces the function `wither`, which gives you a filtering `traverse`. `witherable-class` is a dependency of its heavier counterpart `witherable`, which is why it's relatively small (although it does import `hashable`).

I suggest this because writing `W.filter f someList` is much more readable to me than for example `someList & listElementsL %~ V.Filter f`, and it lets us define filters on `GenericList n f e` polymorphically on `f`.

I can of course just implement this on my end using an orphan instance, but I thought I should bring it to your attention in case you thought it would be useful to add to `brick`.