### PR TITLE
be careful about rewriting empty images

### DIFF
--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -753,13 +753,13 @@ rewriteImage br (loRewrite, hiRewrite) old = rewriteHi . rewriteLo $ old where
     size = imagePrimary br old
     go = rewriteEdge (splitLoSecondary br) (splitHiSecondary br) (concatenateSecondary br)
     rewriteLo img
-        | I.null loRewrite = img
+        | I.null loRewrite || size == 0 = img
         | otherwise = concatenatePrimary br
             [ go loRewrite (splitLoPrimary br 1 img)
             , splitHiPrimary br 1 img
             ]
     rewriteHi img
-        | I.null hiRewrite = img
+        | I.null hiRewrite || size == 0 = img
         | otherwise = concatenatePrimary br
             [ splitLoPrimary br (size-1) img
             , go hiRewrite (splitHiPrimary br (size-1) img)


### PR DESCRIPTION
The following short program crashes when the terminal is 21 rows tall:

```haskell
import Brick
import Brick.Widgets.Border

main :: IO ()
main = simpleMain . joinBorders . vBox $ [str (replicate 20 '\n') :: Widget (), border emptyWidget, hBorder]
```

This happens because the border rewriting code assumes it is rewriting a vty `Image` that actually has content, but the bottom part of the border has already been cropped to height 0. This pull request has a small patch that fixes this by skipping the rewrite if the image has no height (or width, if we are rewriting for an `hBox`).