### PR TITLE
Include clickable elements in the rendering cache.

### DIFF
--- a/src/Brick/Types/Internal.hs
+++ b/src/Brick/Types/Internal.hs
@@ -249,7 +249,7 @@ data RenderState n =
     RS { viewportMap :: !(M.Map n Viewport)
        , rsScrollRequests :: ![(n, ScrollRequest)]
        , observedNames :: !(S.Set n)
-       , renderCache :: !(M.Map n (Result n))
+       , renderCache :: !(M.Map n ([n], Result n))
        , clickableNames :: ![n]
        } deriving (Read, Show, Generic, NFData)
 

--- a/src/Brick/Widgets/Core.hs
+++ b/src/Brick/Widgets/Core.hs
@@ -962,6 +962,11 @@ vRelease p =
 -- use the rendered version from the cache. If not, render the specified
 -- widget and update the cache with the result.
 --
+-- To ensure that mouse events are emitted correctly for cached widgets, 
+-- in addition to the rendered widget, we also cache (the names of) 
+-- any clickable extents that were rendered and restore that when utilizing
+-- the cache.
+--
 -- See also 'invalidateCacheEntry'.
 cached :: (Ord n) => n -> Widget n -> Widget n
 cached n w =
@@ -977,6 +982,8 @@ cached n w =
                 cacheUpdate n (clickables, wResult)
                 return wResult
     where
+        -- Given the rendered result of a Widget, collect the list of "clickable" names
+        -- from the extents that were in the result.
         renderedClickables :: (Ord n) => Result n -> RenderM n [n]
         renderedClickables renderResult = do
             allClickables <- use clickableNamesL


### PR DESCRIPTION
Mouse events for `Widget` were being received inconsistently if/when they are cached. This appears to be because a `Widget`, when rendered update the list of clickable elements that `brick` should track for mouse activity. However, when a `Widget` is cached, this information is lost.

This commit updates the rendering cache to also include the clickable elements exposed by a `Widget` and update `brick`'s tracking list appropriately when utilizing the cache.