### PR TITLE
Fix condition for base version.

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -114,7 +114,7 @@ library
     Brick.Types.Internal
     Brick.Widgets.Internal
 
-  build-depends:       base <= 4.15,
+  build-depends:       base < 4.16,
                        vty >= 5.31,
                        transformers,
                        data-clist >= 0.1,


### PR DESCRIPTION
Unfortunately `base <=4.15` is false for `base-4.15.0.0` so fix condition to `base < 4.16`