### PR TITLE
Includes link to fifteen

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ include it, get in touch!
 | [`ghcup`](https://www.haskell.org/ghcup/) | A TUI for `ghcup`, the Haskell toolchain manager |
 | [`cbookview`](https://github.com/mlang/chessIO) | A TUI for exploring polyglot chess opening book files |
 | [`thock`](https://github.com/rmehri01/thock) | A modern TUI typing game featuring online racing against friends |
+| [`fifteen`](https://github.com/benjaminselfridge/fifteen) | An implementation of the [15 puzzle](https://en.wikipedia.org/wiki/15_puzzle) |
 
 These third-party packages also extend `brick`:
 


### PR DESCRIPTION
This adds a link to my `fifteen` game in the list of brick examples.