### PR TITLE
Edit: Bind more Emacs-compatible keys

### DIFF
--- a/src/Brick/Widgets/Edit.hs
+++ b/src/Brick/Widgets/Edit.hs
@@ -52,6 +52,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Zipper as Z hiding ( textZipper )
 import qualified Data.Text.Zipper.Generic as Z
+import qualified Data.Text.Zipper.Generic.Words as Z
 
 import Brick.Types
 import Brick.Widgets.Core
@@ -64,9 +65,15 @@ import Brick.AttrMap
 -- * Ctrl-a, Home: go to beginning of line
 -- * Ctrl-e, End: go to end of line
 -- * Ctrl-d, Del: delete character at cursor position
+-- * Meta-d: delete word at cursor position
 -- * Backspace: delete character prior to cursor position
 -- * Ctrl-k: delete all from cursor to end of line
 -- * Ctrl-u: delete all from cursor to beginning of line
+-- * Ctrl-t: transpose character before cursor with the one at cursor position
+-- * Meta-b: move one word to the left
+-- * Ctrl-b: move one character to the left
+-- * Meta-f: move one word to the right
+-- * Ctrl-f: move one character to the right
 -- * Arrow keys: move cursor
 -- * Enter: break the current line at the cursor position
 -- * Paste: Bracketed Pastes from the terminal will be pasted, provided
@@ -107,7 +114,8 @@ instance DecodeUtf8 T.Text where
 instance DecodeUtf8 String where
     decodeUtf8 bs = T.unpack <$> decodeUtf8 bs
 
-handleEditorEvent :: (DecodeUtf8 t, Eq t, Monoid t) => Event -> Editor t n -> EventM n (Editor t n)
+handleEditorEvent :: (DecodeUtf8 t, Eq t, Z.GenericTextZipper t)
+                  => Event -> Editor t n -> EventM n (Editor t n)
 handleEditorEvent e ed =
         let f = case e of
                   EvPaste bs -> case decodeUtf8 bs of
@@ -116,6 +124,7 @@ handleEditorEvent e ed =
                   EvKey (KChar 'a') [MCtrl] -> Z.gotoBOL
                   EvKey (KChar 'e') [MCtrl] -> Z.gotoEOL
                   EvKey (KChar 'd') [MCtrl] -> Z.deleteChar
+                  EvKey (KChar 'd') [MMeta] -> Z.deleteWord
                   EvKey (KChar 'k') [MCtrl] -> Z.killToEOL
                   EvKey (KChar 'u') [MCtrl] -> Z.killToBOL
                   EvKey KEnter [] -> Z.breakLine
@@ -125,7 +134,12 @@ handleEditorEvent e ed =
                   EvKey KDown [] -> Z.moveDown
                   EvKey KLeft [] -> Z.moveLeft
                   EvKey KRight [] -> Z.moveRight
+                  EvKey (KChar 'b') [MCtrl] -> Z.moveLeft
+                  EvKey (KChar 'f') [MCtrl] -> Z.moveRight
+                  EvKey (KChar 'b') [MMeta] -> Z.moveWordLeft
+                  EvKey (KChar 'f') [MMeta] -> Z.moveWordRight
                   EvKey KBS [] -> Z.deletePrevChar
+                  EvKey (KChar 't') [MCtrl] -> Z.transposeChars
                   EvKey KHome [] -> Z.gotoBOL
                   EvKey KEnd [] -> Z.gotoEOL
                   EvKey (KChar '<') [MMeta] -> Z.gotoBOF


### PR DESCRIPTION
M-b and M-f to navigate by word
C-b and C-f for consistency
M-d to delete word under cursor
C-t to transpose previous char with current char

This replaces the Monoid constraint on handleEditorEvent with GenericTextZipper
