### PR TITLE
(RFC/proposal/WIP) renderWidget function

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -511,10 +511,11 @@ test-suite brick-tests
   ghc-options:         -Wall -Wcompat -Wno-orphans -O2
   default-language:    Haskell2010
   main-is:             Main.hs
-  other-modules:       List
+  other-modules:       List Render
   build-depends:       base <=5,
                        brick,
                        containers,
                        microlens,
                        vector,
+                       vty,
                        QuickCheck

--- a/src/Brick/Main.hs
+++ b/src/Brick/Main.hs
@@ -47,6 +47,7 @@ module Brick.Main
   , renderFinal
   , getRenderState
   , resetRenderState
+  , renderWidget
   )
 where
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -13,6 +13,7 @@ import qualified Data.IMap as IMap
 import qualified Data.IntMap as IntMap
 
 import qualified List
+import qualified Render
 
 instance Arbitrary v => Arbitrary (Run v) where
     arbitrary = liftA2 (\(Positive n) -> Run n) arbitrary arbitrary
@@ -111,5 +112,5 @@ return []
 
 main :: IO ()
 main =
-  (all id <$> sequenceA [$quickCheckAll, List.main])
+  (all id <$> sequenceA [$quickCheckAll, List.main, Render.main])
   >>= bool exitFailure exitSuccess

--- a/tests/Render.hs
+++ b/tests/Render.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE TypeApplications #-}
+module Render
+  ( main,
+  )
+
+where
+
+import Brick
+import qualified Graphics.Vty as V
+import Brick.Widgets.Border (hBorder)
+
+region :: V.DisplayRegion
+region = (30, 10)
+
+renderToPicture :: Ord n => [Widget n] -> V.Picture
+renderToPicture ws = let (p, _, _) = renderWidget (attrMap V.defAttr []) ws region (const Nothing) in p
+
+renderDisplay :: Ord n => [Widget n] -> IO ()
+renderDisplay ws = do
+  outp <- V.outputForConfig V.defaultConfig
+  ctx <- V.displayContext outp region
+  V.outputPicture ctx (renderToPicture ws)
+
+ui :: Widget ()
+ui = str "Hello, world!"
+
+main :: IO Bool
+main =
+  do 
+      renderDisplay [ui]
+      renderDisplay @() [str "why" <=> hBorder <=> str "not"]
+      return True

--- a/tests/Render.hs
+++ b/tests/Render.hs
@@ -8,6 +8,7 @@ where
 import Brick
 import qualified Graphics.Vty as V
 import Brick.Widgets.Border (hBorder)
+import Control.Exception (try)
 
 region :: V.DisplayRegion
 region = (30, 10)
@@ -28,8 +29,11 @@ renderedMyWidget = "Picture ?? [VertJoin {partTop = VertJoin {partTop = HorizTex
 main :: IO Bool
 main =
   do 
-      renderDisplay [myWidget]
-      
+      result <- try (renderDisplay [myWidget]) :: IO (Either V.VtyConfigurationError ())
+      case result of
+        Left _ -> putStrLn "Terminal is not available"
+        Right () -> return ()
+
       print $ show $ renderWidget [myWidget] region
 
       return $

--- a/tests/Render.hs
+++ b/tests/Render.hs
@@ -12,21 +12,25 @@ import Brick.Widgets.Border (hBorder)
 region :: V.DisplayRegion
 region = (30, 10)
 
-renderToPicture :: Ord n => [Widget n] -> V.Picture
-renderToPicture ws = let (p, _, _) = renderWidget (attrMap V.defAttr []) ws region (const Nothing) in p
-
 renderDisplay :: Ord n => [Widget n] -> IO ()
 renderDisplay ws = do
   outp <- V.outputForConfig V.defaultConfig
   ctx <- V.displayContext outp region
-  V.outputPicture ctx (renderToPicture ws)
+  V.outputPicture ctx (renderWidget ws region)
 
-ui :: Widget ()
-ui = str "Hello, world!"
+myWidget :: Widget ()
+myWidget = str "Why" <=> hBorder <=> str "not?"
+
+-- Since you can't Read a Picture, we have to compare the result with the Shown one
+renderedMyWidget :: String
+renderedMyWidget = "Picture ?? [VertJoin {partTop = VertJoin {partTop = HorizText {attr = Attr {attrStyle = Default, attrForeColor = Default, attrBackColor = Default, attrURL = Default}, displayText = \"Why                           \", outputWidth = 30, charWidth = 30}, partBottom = VertJoin {partTop = HorizText {attr = Attr {attrStyle = Default, attrForeColor = Default, attrBackColor = Default, attrURL = Default}, displayText = \"\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\\9472\", outputWidth = 30, charWidth = 30}, partBottom = HorizText {attr = Attr {attrStyle = Default, attrForeColor = Default, attrBackColor = Default, attrURL = Default}, displayText = \"not?                          \", outputWidth = 30, charWidth = 30}, outputWidth = 30, outputHeight = 2}, outputWidth = 30, outputHeight = 3}, partBottom = BGFill {outputWidth = 30, outputHeight = 7}, outputWidth = 30, outputHeight = 10}] ??"
 
 main :: IO Bool
 main =
   do 
-      renderDisplay [ui]
-      renderDisplay @() [str "why" <=> hBorder <=> str "not"]
-      return True
+      renderDisplay [myWidget]
+      
+      print $ show $ renderWidget [myWidget] region
+
+      return $
+        show (renderWidget [myWidget] region) == renderedMyWidget


### PR DESCRIPTION
This is a work-in-progress Pull Request that I'm making to ask for your opinion on the proposed changes.

This adds a new function, `renderWidget`, that renders a list of widgets into a `V.Picture`. This can be useful with `ghcid` (so one can enjoy hot-reloading their code while working on the UI), and also opens up possibilities for "golden" testing (that would compare the rendered outputs with the golden output).

One way to go about golden testing would be to use `vty`'s `mockTerminal` – that one doesn't output anything pretty, however it can be used to compare the outputs and, should comparison fail, render it in the real terminal. I didn't implement this completely, as I wanted to ask for your input before endeavouring this. If this sounds like a good idea, I could add a couple of simple golden tests as a starting point. They might prove useful for the continued development of the library.

To try using this thing in `ghcid`, the functions defined in `tests/Render.hs` are sufficient.

Unfortunately, there's no way to get this functionality without changing the library somehow, that's why I have to propose this change. An alternative route would be to expose `RenderState` completely, thus making `renderFinal` usable from the outside code. I believe the proposed change is a better approach and can be quite useful even for the library itself.