### PR TITLE
Update documentation for wide character support

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -7,3 +7,23 @@ brick FAQ
   default and requires configuration to make it work. See also:
 
   http://unix.stackexchange.com/questions/110022/how-do-i-find-out-the-keycodes-for-ctrlup-and-down-arrow-for-term-screen
+
+* Q: Why do some emojis mess up the layout?
+* A: For wide characters to be displayed correctly, [vty]'s
+  determination of the character width and the user's
+  terminal emulator's determination of the character width
+  must match. Unforunately, every terminal emulator
+  calulcates this differently, and none correctly follow
+  the Unicode standard.
+  The issue is further complicated by Unicode combining
+  characters and releases of new versions of the Unicode
+  standard. 
+
+  As a result, the current recommendation is to avoid
+  use of wide characters due to these issues.
+  If you still must use them, you can read [vty]'s
+  documentation for options that will affect character
+  width calculations.
+
+
+[vty]: https://hackage.haskell.org/package/vty

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -921,14 +921,16 @@ with ``Brick.Themes.saveCustomizations``.
 Wide Character Support and the TextWidth class
 ==============================================
 
-Brick supports rendering wide characters in all widgets, and the brick
-editor supports entering and editing wide characters. Wide characters
-are those such as many Asian characters and emoji that need more than
-a single terminal column to be displayed. Brick relies on
-`vty's multi-column character support`_ to determine the column width of
-each character rendered, but this requires some additional
-configuration.  Read the details there to configure the correct widths
-for your terminal.
+Brick attempts to support rendering wide characters in all widgets,
+and the brick editor supports entering and editing wide characters.
+Wide characters are those such as many Asian characters and emoji
+that need more than a single terminal column to be displayed.
+
+Unfortunatley, there is not a fully correct solution to determining
+the character width that the user's terminal will use for a given
+character. The current recommendation is to avoid use of wide characters
+due to these issues. If you still must use them, you can read `vty`_'s
+documentation for options that will affect character width calculations.
 
 As a result of supporting wide characters, it is important to know that
 computing the length of a string to determine its screen width will
@@ -1923,7 +1925,6 @@ or ``mapAttrNames`` to convert its custom names to the names that the
 sub-widget uses for rendering its output.
 
 .. _vty: https://github.com/jtdaugherty/vty
-.. _vty's multi-column character support: https://github.com/jtdaugherty/vty#multi-column-character-support
 .. _Hackage: http://hackage.haskell.org/
 .. _microlens: http://hackage.haskell.org/package/microlens
 .. _bracketed paste mode: https://cirw.in/blog/bracketed-paste

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -924,9 +924,11 @@ Wide Character Support and the TextWidth class
 Brick supports rendering wide characters in all widgets, and the brick
 editor supports entering and editing wide characters. Wide characters
 are those such as many Asian characters and emoji that need more than
-a single terminal column to be displayed. Brick relies on Vty's use of
-the `utf8proc`_ library to determine the column width of each character
-rendered.
+a single terminal column to be displayed. Brick relies on
+`vty's multi-column character support`_ to determine the column width of
+each character rendered, but this requires some additional
+configuration.  Read the details there to configure the correct widths
+for your terminal.
 
 As a result of supporting wide characters, it is important to know that
 computing the length of a string to determine its screen width will
@@ -945,8 +947,8 @@ will not be counted properly. In order to get this right, use the
 
    let width = Brick.Widgets.Core.textWidth t
 
-The ``TextWidth`` type class uses Vty's character width routine (and
-thus ``utf8proc``) to compute the correct width. If you need to compute
+The ``TextWidth`` type class uses Vty's character width routine
+to compute the correct width. If you need to compute
 the width of a single character, use ``Graphics.Text.wcwidth``.
 
 Extents
@@ -1921,7 +1923,7 @@ or ``mapAttrNames`` to convert its custom names to the names that the
 sub-widget uses for rendering its output.
 
 .. _vty: https://github.com/jtdaugherty/vty
+.. _vty's multi-column character support: https://github.com/jtdaugherty/vty#multi-column-character-support
 .. _Hackage: http://hackage.haskell.org/
 .. _microlens: http://hackage.haskell.org/package/microlens
 .. _bracketed paste mode: https://cirw.in/blog/bracketed-paste
-.. _utf8proc: http://julialang.org/utf8proc/


### PR DESCRIPTION
The guide says "Brick relies on Vty's use of the [utf8proc](http://julialang.org/utf8proc/) library to determine the column width of each character rendered." but use of utf8proc was removed in vty-5.13  https://github.com/jtdaugherty/vty/commit/cd534c1028b3efde9c13218a10b7e085958496bc.

This updates the brick guide to point to how to configure the new way of computing character widths that was since added.  (It took me a few hours of digging through issue histories to find this and understand that it was the current correct way!)