### PR TITLE
Add GHC 9.4.2 to CI config

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.4
             compilerKind: ghc
             compilerVersion: 9.2.4

--- a/brick.cabal
+++ b/brick.cabal
@@ -38,7 +38,7 @@ build-type:          Simple
 cabal-version:       1.18
 Homepage:            https://github.com/jtdaugherty/brick/
 Bug-reports:         https://github.com/jtdaugherty/brick/issues
-tested-with:         GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4
+tested-with:         GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4, GHC == 9.4.2
 
 extra-doc-files:     README.md,
                      docs/guide.rst,
@@ -118,7 +118,7 @@ library
     Brick.Types.Internal
     Brick.Widgets.Internal
 
-  build-depends:       base >= 4.9.0.0 && < 4.17.0.0,
+  build-depends:       base >= 4.9.0.0 && < 4.18.0.0,
                        vty >= 5.36,
                        bimap >= 0.5 && < 0.6,
                        data-clist >= 0.1,


### PR DESCRIPTION
Yesterday I opened a [PR](https://github.com/aisamanra/config-ini/pull/36) in config-ini to allow it being built with GHC 9.4.2.
The author was kind enough to accept it and release associated version on hackage.
This unblocks building brick with GHC 9.4.2 :champagne: 
