### PR TITLE
Use ghcup as setup-method for all compiler versions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -55,22 +55,22 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:


### PR DESCRIPTION
An attempt to deal with these CI errors. Let's see if it helps..
```
Cannot add PPA: 'ppa:~hvr/ubuntu/ghc'.
ERROR: '~hvr' user or team does not exist.
Error: Process completed with exit code 1.
```

Question about this raised in haskell-ci repo: https://github.com/haskell-CI/haskell-ci/issues/621