### PR TITLE
renderBox: performance improvements

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -123,7 +123,6 @@ library
                        bimap >= 0.5 && < 0.6,
                        data-clist >= 0.1,
                        directory >= 1.2.5.0,
-                       dlist,
                        exceptions >= 0.10.0,
                        filepath,
                        containers >= 0.5.7,


### PR DESCRIPTION
I eked out a couple of small gains, before I noticed the big one hiding in
plain sight.  This PR brings a big improvement to rendering long chains of
widgets in `vBox` and `hBox`.

```
d043df6 (Fraser Tweedale, 2 hours ago)
   renderBox: avoid O(n²) slowdowns

   `renderBox` computes translations by summing the primary dimensions of
   widgets preceding the current widget.  This has O(n²) complexity and causes
   poor performance with long lists of widgets.  In one purebred scenario
   `renderBox` contributes ~30% of the CPU time of the program.

   Use a State computation to accumulate the total offset during the 
   traversal.  In the scenario described above, this change caused
   `renderBox` to drop to >4% of the program CPU time.

   Also remove another `sum` that calculates remaining the remaning primary
   dimension space after rendering of greedy widgets.  We already calculated
   this value during the greedy widget render traversal, so reuse it.

35874d5 (Fraser Tweedale, 10 hours ago)
   renderBox: use strict state monad

   Using the strict state monad to calculate `renderedHis` brings another
   small performance increase.

   I find the StateT version a little easier to comprehend too, although it's
   a subjective matter.

2b97d32 (Fraser Tweedale, 10 hours ago)
   renderBox: avoid unnecessary use of dlist

   `renderBox` uses dlist to grow the result list while doing a render 
   traversal.  An ordinary fmap'd list construction suffices and offers a very
   small but measurable performance boost.

   Furthermore this is the only place the *dlist* library was used so
   *brick* no longer depends on it.
```