### PR TITLE
Add a function to create an attribute from a specified style

### DIFF
--- a/src/Brick/Util.hs
+++ b/src/Brick/Util.hs
@@ -52,7 +52,7 @@ fg :: Color -> Attr
 fg = (defAttr `withForeColor`)
 
 -- | Create an attribute from the specified background color (the
--- background color is the "default").
+-- foreground color is the "default").
 bg :: Color -> Attr
 bg = (defAttr `withBackColor`)
 

--- a/src/Brick/Util.hs
+++ b/src/Brick/Util.hs
@@ -4,6 +4,7 @@ module Brick.Util
   , on
   , fg
   , bg
+  , style
   , clOffset
   )
 where
@@ -55,6 +56,11 @@ fg = (defAttr `withForeColor`)
 -- foreground color is the "default").
 bg :: Color -> Attr
 bg = (defAttr `withBackColor`)
+
+-- | Create an attribute from the specified style (the colors are the
+-- "default").
+style :: Style -> Attr
+style = (defAttr `withStyle`)
 
 -- | Add a 'Location' offset to the specified 'CursorLocation'.
 clOffset :: CursorLocation n -> Location -> CursorLocation n


### PR DESCRIPTION
The new function `Brick.Util.style` is analogous to the existing `fg` and `bg` functions.

Also fix a small wording mistake in `bg`'s Haddock.