### PR TITLE
Make it build with ghc 9.8 (update deps only)

### DIFF
--- a/brick.cabal
+++ b/brick.cabal
@@ -94,7 +94,7 @@ library
     Brick.Types.Internal
     Brick.Widgets.Internal
 
-  build-depends:       base >= 4.9.0.0 && < 4.19.0.0,
+  build-depends:       base >= 4.9.0.0 && < 4.21.0.0,
                        vty >= 6.0,
                        vty-crossplatform,
                        bimap >= 0.5 && < 0.6,
@@ -113,7 +113,7 @@ library
                        text,
                        text-zipper >= 0.13,
                        template-haskell,
-                       deepseq >= 1.3 && < 1.5,
+                       deepseq >= 1.3 && < 1.6,
                        unix-compat,
                        bytestring,
                        word-wrap >= 0.2


### PR DESCRIPTION
I had to add a `cabal.project`  file containing:
```
packages:
  .

allow-newer:
  , data-clist:deepseq
  , config-ini:containers
  , config-ini:text
```
I already have PRs open for those two packages.

This can be fixed with a Hackage metadata edit.