### PR TITLE
Fix defaultMain not shutting down Vty

### DIFF
--- a/src/Brick/Main.hs
+++ b/src/Brick/Main.hs
@@ -131,8 +131,10 @@ defaultMain :: (Ord n)
             -> s
             -- ^ The initial application state.
             -> IO s
-defaultMain app st =
-    fst <$> customMainWithDefaultVty Nothing app st
+defaultMain app st = do
+    let builder = mkVty defaultConfig
+    initialVty <- builder
+    customMain initialVty builder Nothing app st
 
 -- | A simple main entry point which takes a widget and renders it. This
 -- event loop terminates when the user presses any key, but terminal


### PR DESCRIPTION
Disclaimer: This is my first time contributing anything to a Haskell project, so please be gentle ❤️

This reverts a part of c1aef1106eb537d94041ef502174ba0dc97887c0, specifically `defaultMain` using `customMainWithDefaultVty` under the hood.

As a new Haskell user, (on Windows), I was quickly drawn to brick, with its really impressive feature set and awesome architecture.
I hit some road blocks, though, trying out the examples (specifically in brick-2.1):
When running most of the demo projects, My terminal completely "breaks" after terminating the tui app, this is event the case for the Hello World demo.
Here is an example:
![image](https://github.com/jtdaugherty/brick/assets/2969321/6645bb30-8f87-4753-9cb4-d9a1adf85cb7)
You can see that, after terminating the app, the screen is not cleared, I lose prompt colors, and my cursor is invisible.

I noticed the recent change to `defaultMain`, where it just wraps `customMainWithDefaultVty`, returning the state, but ignoring the `Vty`

Looking at the description of `customMainWithDefaultVty`, I saw that it leaves it up to the user to continue using the `Vty` and shut it down. In `customMain` I can see we are indeed shutting down and restoring the initial state, which I think is reasonable to do in a simpleMain use case.

What do you think?