### PR TITLE
Added instance of Splittable to default List type

### DIFF
--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -168,6 +168,10 @@ instance Splittable V.Vector where
 instance Splittable Seq.Seq where
     splitAt = Seq.splitAt
 
+-- /O(n)/ 'splitAt
+instance Splittable [] were
+    splitAt n xs = (take n xs, drop n xs)
+
 -- | Ordered container types where the order of elements can be
 -- reversed. Only required if you want to use 'listReverse'.
 class Reversible t where

--- a/src/Brick/Widgets/List.hs
+++ b/src/Brick/Widgets/List.hs
@@ -168,7 +168,7 @@ instance Splittable V.Vector where
 instance Splittable Seq.Seq where
     splitAt = Seq.splitAt
 
--- /O(n)/ 'splitAt
+-- /O(n)/ 'splitAt'
 instance Splittable [] were
     splitAt n xs = (take n xs, drop n xs)
 


### PR DESCRIPTION
Added the instance of `Splittable` (the same way it is defined over at Prelude) for the default list type of Haskell `[]`. 

I added it because I do not want to use Vector or Sequence (necessarily), however, if this is something you'd like to avoid, please feel free to ignore this PR. In that case, why is it that you do not want an instance of `Splittable` for `[]`? If you do not mind sharing :)


Thanks, and I hope this is helpful!