### PR TITLE
`ProgressBar` variants

### DIFF
--- a/programs/ProgressBarDemo.hs
+++ b/programs/ProgressBarDemo.hs
@@ -26,7 +26,7 @@ import Brick.Widgets.Core
   )
 import Brick.Util (fg, bg, on, clamp)
 
-data MyAppState n = MyAppState { _x, _y, _z :: Float }
+data MyAppState n = MyAppState { _x, _y, _z :: Float, _showLabel :: Bool }
 
 makeLenses ''MyAppState
 
@@ -48,13 +48,65 @@ drawUI p = [ui]
       zBar = overrideAttr P.progressCompleteAttr zDoneAttr $
              overrideAttr P.progressIncompleteAttr zToDoAttr $
              bar $ _z p
-      lbl c = Just $ show $ fromEnum $ c * 100
+      -- custom bars
+      cBar1 = overrideAttr P.progressCompleteAttr cDoneAttr1 $
+              overrideAttr P.progressIncompleteAttr cToDoAttr1 
+              $ bar' (_x p) ('━', '━')
+      cBar2 = overrideAttr P.progressCompleteAttr cDoneAttr2 $
+              overrideAttr P.progressIncompleteAttr cToDoAttr2
+              $ bar' (_y p) ('▰', '▰')
+      cBar3 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_z p) ('━', '─')
+      cBar4 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_x p) ('▰', '▱')
+      cBar5 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_y p) ('━', '=')
+      cBar6 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_z p) ('█', '▁')
+      cBar7 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_x p) ('■', '□')
+      cBar8 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_y p) ('▪', '▫')
+      cBar9 = overrideAttr P.progressCompleteAttr cDoneAttr $
+              overrideAttr P.progressIncompleteAttr cToDoAttr 
+              $ bar' (_z p) ('▸', '▹')
+      cBar10 = overrideAttr P.progressCompleteAttr cDoneAttr $
+               overrideAttr P.progressIncompleteAttr cToDoAttr 
+               $ bar' (_x p) ('⣿', '⠶')
+      cBar11 = overrideAttr P.progressCompleteAttr cDoneAttr $
+               overrideAttr P.progressIncompleteAttr cToDoAttr 
+               $ bar' (_y p) ('|', '=')
+      cBar12 = overrideAttr P.progressCompleteAttr cDoneAttr $
+               overrideAttr P.progressIncompleteAttr cToDoAttr 
+               $ bar' (_z p) ('●', '⊙')
+      lbl c = if _showLabel p 
+              then Just $ " " ++ (show $ fromEnum $ c * 100) ++ " " 
+              else Nothing
       bar v = P.progressBar (lbl v) v
+      bar' v chars = P.progressBar' (lbl v) v chars
       ui = (str "X: " <+> xBar) <=>
            (str "Y: " <+> yBar) <=>
            (str "Z: " <+> zBar) <=>
+           (str "X: " <+> cBar1) <=>
+           (str "Y: " <+> cBar2) <=>
+           (str "Z: " <+> cBar3) <=>
+           (str "X: " <+> cBar4) <=>
+           (str "Y: " <+> cBar5) <=>
+           (str "Z: " <+> cBar6) <=>
+           (str "X: " <+> cBar7) <=>
+           (str "Y: " <+> cBar8) <=>
+           (str "Z: " <+> cBar9) <=>
+           (str "X: " <+> cBar10) <=>
+           (str "Y: " <+> cBar11) <=>
+           (str "Z: " <+> cBar12) <=>
            str "" <=>
-           str "Hit 'x', 'y', or 'z' to advance progress, or 'q' to quit"
+           str "Hit 'x', 'y', or 'z' to advance progress, 'r' to revert values, 'cmd + r' to reset values or 'q' to quit"
 
 appEvent :: T.BrickEvent () e -> T.EventM () (MyAppState ()) ()
 appEvent (T.VtyEvent e) =
@@ -63,12 +115,18 @@ appEvent (T.VtyEvent e) =
          V.EvKey (V.KChar 'x') [] -> x %= valid . (+ 0.05)
          V.EvKey (V.KChar 'y') [] -> y %= valid . (+ 0.03)
          V.EvKey (V.KChar 'z') [] -> z %= valid . (+ 0.02)
+         V.EvKey (V.KChar 't') [] -> showLabel %= not
+         V.EvKey (V.KChar 'r') [V.MCtrl] -> do
+           x .= 0
+           y .= 0
+           z .= 0
+         V.EvKey (V.KChar 'r') [] -> T.put initialState
          V.EvKey (V.KChar 'q') [] -> M.halt
          _ -> return ()
 appEvent _ = return ()
 
 initialState :: MyAppState ()
-initialState = MyAppState 0.25 0.18 0.63
+initialState = MyAppState 0.25 0.18 0.63 True
 
 theBaseAttr :: A.AttrName
 theBaseAttr = A.attrName "theBase"
@@ -85,6 +143,18 @@ zDoneAttr, zToDoAttr :: A.AttrName
 zDoneAttr = theBaseAttr <> A.attrName "Z:done"
 zToDoAttr = theBaseAttr <> A.attrName "Z:remaining"
 
+cDoneAttr, cToDoAttr :: A.AttrName
+cDoneAttr = A.attrName "C:done"
+cToDoAttr = A.attrName "C:remaining"
+
+cDoneAttr1, cToDoAttr1 :: A.AttrName
+cDoneAttr1 = A.attrName "C1:done"
+cToDoAttr1 = A.attrName "C1:remaining"
+
+cDoneAttr2, cToDoAttr2 :: A.AttrName
+cDoneAttr2 = A.attrName "C2:done"
+cToDoAttr2 = A.attrName "C2:remaining"
+
 theMap :: A.AttrMap
 theMap = A.attrMap V.defAttr
          [ (theBaseAttr,               bg V.brightBlack)
@@ -93,6 +163,12 @@ theMap = A.attrMap V.defAttr
          , (yDoneAttr,                 V.magenta `on` V.yellow)
          , (zDoneAttr,                 V.blue `on` V.green)
          , (zToDoAttr,                 V.blue `on` V.red)
+         , (cDoneAttr,                 fg V.blue)
+         , (cToDoAttr,                 fg V.blue)
+         , (cDoneAttr1,                fg V.white)
+         , (cToDoAttr1,                fg V.black)
+         , (cDoneAttr2,                fg V.yellow)
+         , (cToDoAttr2,                fg V.black)
          , (P.progressIncompleteAttr,  fg V.yellow)
          ]
 

--- a/programs/ProgressBarDemo.hs
+++ b/programs/ProgressBarDemo.hs
@@ -21,6 +21,7 @@ import Brick.Types
 import Brick.Widgets.Core
   ( (<+>), (<=>)
   , str
+  , strWrap
   , updateAttrMap
   , overrideAttr
   )
@@ -51,62 +52,26 @@ drawUI p = [ui]
       -- custom bars
       cBar1 = overrideAttr P.progressCompleteAttr cDoneAttr1 $
               overrideAttr P.progressIncompleteAttr cToDoAttr1 
-              $ bar' (_x p) ('━', '━')
+              $ bar' '▰' '▱' $ _x p
       cBar2 = overrideAttr P.progressCompleteAttr cDoneAttr2 $
               overrideAttr P.progressIncompleteAttr cToDoAttr2
-              $ bar' (_y p) ('▰', '▰')
+              $ bar' '|' '─' $ _y p
       cBar3 = overrideAttr P.progressCompleteAttr cDoneAttr $
               overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_z p) ('━', '─')
-      cBar4 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_x p) ('▰', '▱')
-      cBar5 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_y p) ('━', '=')
-      cBar6 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_z p) ('█', '▁')
-      cBar7 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_x p) ('■', '□')
-      cBar8 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_y p) ('▪', '▫')
-      cBar9 = overrideAttr P.progressCompleteAttr cDoneAttr $
-              overrideAttr P.progressIncompleteAttr cToDoAttr 
-              $ bar' (_z p) ('▸', '▹')
-      cBar10 = overrideAttr P.progressCompleteAttr cDoneAttr $
-               overrideAttr P.progressIncompleteAttr cToDoAttr 
-               $ bar' (_x p) ('⣿', '⠶')
-      cBar11 = overrideAttr P.progressCompleteAttr cDoneAttr $
-               overrideAttr P.progressIncompleteAttr cToDoAttr 
-               $ bar' (_y p) ('|', '=')
-      cBar12 = overrideAttr P.progressCompleteAttr cDoneAttr $
-               overrideAttr P.progressIncompleteAttr cToDoAttr 
-               $ bar' (_z p) ('●', '⊙')
+              $ bar' '⣿' '⠶' $ _z p
       lbl c = if _showLabel p 
               then Just $ " " ++ (show $ fromEnum $ c * 100) ++ " " 
               else Nothing
       bar v = P.progressBar (lbl v) v
-      bar' v chars = P.progressBar' (lbl v) v chars
+      bar' cc ic v = P.customProgressBar cc ic (lbl v) v
       ui = (str "X: " <+> xBar) <=>
            (str "Y: " <+> yBar) <=>
            (str "Z: " <+> zBar) <=>
            (str "X: " <+> cBar1) <=>
            (str "Y: " <+> cBar2) <=>
            (str "Z: " <+> cBar3) <=>
-           (str "X: " <+> cBar4) <=>
-           (str "Y: " <+> cBar5) <=>
-           (str "Z: " <+> cBar6) <=>
-           (str "X: " <+> cBar7) <=>
-           (str "Y: " <+> cBar8) <=>
-           (str "Z: " <+> cBar9) <=>
-           (str "X: " <+> cBar10) <=>
-           (str "Y: " <+> cBar11) <=>
-           (str "Z: " <+> cBar12) <=>
            str "" <=>
-           str "Hit 'x', 'y', or 'z' to advance progress, 'r' to revert values, 'cmd + r' to reset values or 'q' to quit"
+           strWrap "Hit 'x', 'y', or 'z' to advance progress, 't' to toggle labels, 'r' to revert values, 'cmd + r' to reset values or 'q' to quit"
 
 appEvent :: T.BrickEvent () e -> T.EventM () (MyAppState ()) ()
 appEvent (T.VtyEvent e) =
@@ -165,10 +130,10 @@ theMap = A.attrMap V.defAttr
          , (zToDoAttr,                 V.blue `on` V.red)
          , (cDoneAttr,                 fg V.blue)
          , (cToDoAttr,                 fg V.blue)
-         , (cDoneAttr1,                fg V.white)
-         , (cToDoAttr1,                fg V.black)
-         , (cDoneAttr2,                fg V.yellow)
-         , (cToDoAttr2,                fg V.black)
+         , (cDoneAttr1,                fg V.red)
+         , (cToDoAttr1,                fg V.brightWhite)
+         , (cDoneAttr2,                fg V.green)
+         , (cToDoAttr2,                fg V.brightGreen)
          , (P.progressIncompleteAttr,  fg V.yellow)
          ]
 

--- a/src/Brick/Widgets/ProgressBar.hs
+++ b/src/Brick/Widgets/ProgressBar.hs
@@ -3,7 +3,7 @@
 -- | This module provides a progress bar widget.
 module Brick.Widgets.ProgressBar
   ( progressBar
-  , progressBar'
+  , customProgressBar
   -- * Attributes
   , progressCompleteAttr
   , progressIncompleteAttr
@@ -38,24 +38,24 @@ progressBar :: Maybe String
             -> Float
             -- ^ The progress value. Should be between 0 and 1 inclusive.
             -> Widget n
-progressBar mLabel progress =
-    progressBar' mLabel progress (' ', ' ')
+progressBar = customProgressBar ' ' ' '
 
 -- | Draw a progress bar with the specified (optional) label,
--- progress value and a pair of characters to fill the progress. 
+-- progress value and custom characters to fill the progress.
 -- This fills available horizontal space and is one row high.
-progressBar' :: Maybe String
-             -- ^ The label. If specified, this is shown in the center of
-             -- the progress bar.
-             -> Float
-             -- ^ The progress value. Should be between 0 and 1 inclusive.
-             -> (Char, Char)
-             -- ^ Pair of characters to fill the bar. First character is used 
-             -- to fill the completed part, second character draws the uncompleted part.
-             -- Please be aware of using wide characters in Brick, 
-             -- see [Wide Character Support and the TextWidth class](https://github.com/jtdaugherty/brick/blob/master/docs/guide.rst#wide-character-support-and-the-textwidth-class)
-             -> Widget n
-progressBar' mLabel progress (completeChar, uncompleteChar) =
+-- Please be aware of using wide characters in Brick,
+-- see [Wide Character Support and the TextWidth class](https://github.com/jtdaugherty/brick/blob/master/docs/guide.rst#wide-character-support-and-the-textwidth-class)
+customProgressBar :: Char
+                  -- ^ Character to fill the completed part.
+                  -> Char
+                  -- ^ Character to fill the incomplete part.
+                  -> Maybe String
+                  -- ^ The label. If specified, this is shown in the center of
+                  -- the progress bar.
+                  -> Float
+                  -- ^ The progress value. Should be between 0 and 1 inclusive.
+                  -> Widget n
+customProgressBar completeChar incompleteChar mLabel progress =
     Widget Greedy Fixed $ do
         c <- getContext
         let barWidth = c^.availWidthL
@@ -67,11 +67,11 @@ progressBar' mLabel progress (completeChar, uncompleteChar) =
             completeWidth = round $ progress * toEnum barWidth
             
             leftCompleteWidth = min leftWidth completeWidth
-            leftIncompleteWidth = leftWidth - leftCompleteWidth         
-            leftPart = replicate leftCompleteWidth completeChar ++ replicate leftIncompleteWidth uncompleteChar
+            leftIncompleteWidth = leftWidth - leftCompleteWidth
+            leftPart = replicate leftCompleteWidth completeChar ++ replicate leftIncompleteWidth incompleteChar
             rightCompleteWidth = max 0 (completeWidth - labelWidth - leftWidth)
             rightIncompleteWidth = rightWidth - rightCompleteWidth
-            rightPart = replicate rightCompleteWidth completeChar ++ replicate rightIncompleteWidth uncompleteChar
+            rightPart = replicate rightCompleteWidth completeChar ++ replicate rightIncompleteWidth incompleteChar
     
             fullBar = leftPart <> label <> rightPart
             adjustedCompleteWidth = if completeWidth == length fullBar && progress < 1.0

--- a/src/Brick/Widgets/ProgressBar.hs
+++ b/src/Brick/Widgets/ProgressBar.hs
@@ -1,24 +1,26 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+
 -- | This module provides a progress bar widget.
 module Brick.Widgets.ProgressBar
   ( progressBar
+  , progressBar'
   -- * Attributes
   , progressCompleteAttr
   , progressIncompleteAttr
   )
 where
 
-import Lens.Micro ((^.))
 import Data.Maybe (fromMaybe)
+import Lens.Micro ((^.))
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid
 #endif
-import Graphics.Vty (safeWcswidth)
-
-import Brick.Types
 import Brick.AttrMap
+import Brick.Types
 import Brick.Widgets.Core
+import Graphics.Vty (safeWcswidth)
 
 -- | The attribute of the completed portion of the progress bar.
 progressCompleteAttr :: AttrName
@@ -38,16 +40,41 @@ progressBar :: Maybe String
             -- ^ The progress value. Should be between 0 and 1 inclusive.
             -> Widget n
 progressBar mLabel progress =
+    progressBar' mLabel progress (' ', ' ')
+
+-- | Draw a progress bar with the specified (optional) label,
+-- progress value and a pair of characters to fill the progress. 
+-- This fills available horizontal space and is one row high.
+progressBar' :: Maybe String
+             -- ^ The label. If specified, this is shown in the center of
+             -- the progress bar.
+             -> Float
+             -- ^ The progress value. Should be between 0 and 1 inclusive.
+             -> (Char, Char)
+             -- ^ Pair of characters to fill the bar. First character is used 
+             -- to fill the completed part, second character draws the uncompleted part.
+             -- Please be aware of using wide characters in Brick, 
+             -- see [Wide Character Support and the TextWidth class](https://github.com/jtdaugherty/brick/blob/master/docs/guide.rst#wide-character-support-and-the-textwidth-class)
+             -> Widget n
+progressBar' mLabel progress (completeChar, uncompleteChar) =
     Widget Greedy Fixed $ do
         c <- getContext
-        let barWidth = c^.availWidthL
+        let barWidth = c ^. availWidthL
             label = fromMaybe "" mLabel
             labelWidth = safeWcswidth label
             spacesWidth = barWidth - labelWidth
-            leftPart = replicate (spacesWidth `div` 2) ' '
-            rightPart = replicate (barWidth - (labelWidth + length leftPart)) ' '
+            leftWidth = spacesWidth `div` 2
+            rightWidth = barWidth - labelWidth - leftWidth
+            completeWidth = round $ progress * toEnum barWidth
+            
+            leftCompleteWidth = min leftWidth completeWidth
+            leftIncompleteWidth = leftWidth - leftCompleteWidth         
+            leftPart = replicate leftCompleteWidth completeChar ++ replicate leftIncompleteWidth uncompleteChar
+            rightCompleteWidth = max 0 (completeWidth - labelWidth - leftWidth)
+            rightIncompleteWidth = rightWidth - rightCompleteWidth
+            rightPart = replicate rightCompleteWidth completeChar ++ replicate rightIncompleteWidth uncompleteChar
+    
             fullBar = leftPart <> label <> rightPart
-            completeWidth = round $ progress * toEnum (length fullBar)
             adjustedCompleteWidth = if completeWidth == length fullBar && progress < 1.0
                                     then completeWidth - 1
                                     else if completeWidth == 0 && progress > 0.0

--- a/src/Brick/Widgets/ProgressBar.hs
+++ b/src/Brick/Widgets/ProgressBar.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
-
 -- | This module provides a progress bar widget.
 module Brick.Widgets.ProgressBar
   ( progressBar
@@ -12,15 +10,16 @@ module Brick.Widgets.ProgressBar
   )
 where
 
-import Data.Maybe (fromMaybe)
 import Lens.Micro ((^.))
+import Data.Maybe (fromMaybe)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid
 #endif
-import Brick.AttrMap
-import Brick.Types
-import Brick.Widgets.Core
 import Graphics.Vty (safeWcswidth)
+
+import Brick.Types
+import Brick.AttrMap
+import Brick.Widgets.Core
 
 -- | The attribute of the completed portion of the progress bar.
 progressCompleteAttr :: AttrName
@@ -59,7 +58,7 @@ progressBar' :: Maybe String
 progressBar' mLabel progress (completeChar, uncompleteChar) =
     Widget Greedy Fixed $ do
         c <- getContext
-        let barWidth = c ^. availWidthL
+        let barWidth = c^.availWidthL
             label = fromMaybe "" mLabel
             labelWidth = safeWcswidth label
             spacesWidth = barWidth - labelWidth


### PR DESCRIPTION
Introduce ~~`progressBar'` (note the `'`)~~ `customProgressBar` to let users customize the `ProgressBar`.

Example: Using `'▰'` and `'▱'` draws following progress bar:

```sh
▰▰▰▰▰▰▰▰▰▰ 60% ▰▰▱▱▱▱▱▱▱▱
```
No api change.

## Demo
_(click image to see original size)_

![brick-custom-progressbar](https://github.com/user-attachments/assets/d0ea087b-4c6b-40eb-a9b5-c179ae056625)
