### PR TITLE
Fix right padding calculation for horizontal centering

### DIFF
--- a/src/Brick/Widgets/Center.hs
+++ b/src/Brick/Widgets/Center.hs
@@ -60,9 +60,8 @@ hCenterWith mChar p =
            c <- getContext
            let rWidth = result^.imageL.to imageWidth
                rHeight = result^.imageL.to imageHeight
-               remainder = max 0 $ c^.availWidthL - (leftPaddingAmount * 2)
                leftPaddingAmount = max 0 $ (c^.availWidthL - rWidth) `div` 2
-               rightPaddingAmount = max 0 $ leftPaddingAmount + remainder
+               rightPaddingAmount = max 0 $ c^.availWidthL - leftPaddingAmount - rWidth
                leftPadding = charFill (c^.attrL) ch leftPaddingAmount rHeight
                rightPadding = charFill (c^.attrL) ch rightPaddingAmount rHeight
                paddedImage = horizCat [ leftPadding


### PR DESCRIPTION
The calculations for right padding on horizontal centering don't seem right:

If `availWidth` is 30, and `rWidth` is 10, then `leftPaddingAmount` will be 10.  From this, `remainder` will be `10` and `rightPaddingAmount` will be 20, which is too large, giving a total width of 10 + 10 + 20 = 40.

Similarly, if `availWidth` is 30 and `rWidth` is 11, then `leftPaddingAmount` will be 8.  From this, `remainder` will be `14`, and `rPaddingAmount` will be 22, giving a total width of 8 + 11 + 22 = 41.

This patch provides a new calculation for `rPaddingAmount`, which will be 10 and 12, respectively, both giving a resulting length of 30 which matches `availWidth`.

This does not produce any visible differences on rendering simple scenarios because `vty` will apply cropping to the `Image` generated, but it may provide invalid width values for general calculations if there is a `Widget` to the left or right of the centered `Widget`.

It may be that `vCenterWith` has the same type of error; I did not investigate that function in detail.