### PR TITLE
Added str import in case Haddock couldn't the str file, moved simpleA…

### DIFF
--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,1 @@
+tests: True

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,1 +1,1 @@
-tests: True
+

--- a/src/Brick/Main.hs
+++ b/src/Brick/Main.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE RankNTypes #-}
 module Brick.Main
   ( App(..)
+  , simpleApp
   , defaultMain
   , customMain
   , customMainWithVty
   , customMainWithDefaultVty
   , simpleMain
   , resizeOrQuit
-  , simpleApp
 
   -- * Event handler functions
   , continueWithoutRedraw
@@ -85,6 +85,7 @@ import Brick.BChan (BChan, newBChan, readBChan, readBChan2, writeBChan)
 import Brick.Types.EventM
 import Brick.Types.Internal
 import Brick.Widgets.Internal
+import Brick.Widgets.Core (str)
 import Brick.AttrMap
 
 -- | The library application abstraction. Your application's operations
@@ -122,6 +123,25 @@ data App s e n =
         -- ^ The attribute map that should be used during rendering.
         }
 
+-- | A simple application with reasonable defaults to be overridden as
+-- desired:
+--
+-- * Draws only the specified widget
+-- * Quits on any event other than resizes
+-- * Has no start event handler
+-- * Provides no attribute map
+-- * Never shows any cursors
+--
+-- Try providing it a 'str' widget to try it out.
+simpleApp :: Widget n -> App s e n
+simpleApp w =
+    App { appDraw = const [w]
+        , appHandleEvent = resizeOrQuit
+        , appStartEvent = return ()
+        , appAttrMap = const $ attrMap defAttr []
+        , appChooseCursor = neverShowCursor
+        }
+
 -- | The default main entry point which takes an application and an
 -- initial state and returns the final state from 'EventM' once the
 -- program exits.
@@ -144,23 +164,6 @@ simpleMain :: (Ord n)
            -- ^ The widget to draw.
            -> IO ()
 simpleMain w = defaultMain (simpleApp w) ()
-
--- | A simple application with reasonable defaults to be overridden as
--- desired:
---
--- * Draws only the specified widget
--- * Quits on any event other than resizes
--- * Has no start event handler
--- * Provides no attribute map
--- * Never shows any cursors
-simpleApp :: Widget n -> App s e n
-simpleApp w =
-    App { appDraw = const [w]
-        , appHandleEvent = resizeOrQuit
-        , appStartEvent = return ()
-        , appAttrMap = const $ attrMap defAttr []
-        , appChooseCursor = neverShowCursor
-        }
 
 -- | An event-handling function which continues execution of the event
 -- loop only when resize events occur; all other types of events trigger


### PR DESCRIPTION
…pp closer to the App datatype for greater visibility, increased explicitness on simpleApp's description.

Actually, I recently hacked together a primitive Tetris game with Brick, and one of the issues I disliked was how difficult it was to build a simple full-fledged program because I couldn't find a good defaultApp configuration which I could override.

Given the choice, actually, I'd rather take away the widget parameter from simpleApp, defaulting to "str \"Hello, Brick!\"", but to avoid others having similar issues, I moved simpleApp next to the App datatype, added str imports so Haddock could point to the widget.