### PR TITLE
doc: clarify that Vty from customMainWithDefaultVty needs shutdown

### DIFF
--- a/src/Brick/Main.hs
+++ b/src/Brick/Main.hs
@@ -238,6 +238,10 @@ customMain initialVty buildVty mUserChan app initialAppState = do
 
 -- | Like 'customMainWithVty', except that Vty is initialized with the
 -- default configuration.
+--
+-- The Vty is live when returned to the caller.  Use 'shutdown' to
+-- finalise it.
+--
 customMainWithDefaultVty :: (Ord n)
                          => Maybe (BChan e)
                          -- ^ An event channel for sending custom


### PR DESCRIPTION
I wondered whether perhaps `customMainWithDefaultVty` ought to shut down the vty it creates, but since the return type includes the Vty, we probably should leave it as is, and just update the doc to clarify that it needs to be shut down.